### PR TITLE
Fix Javadoc warnings regarding author's email address

### DIFF
--- a/open-reac/src/main/java/com/powsybl/openreac/OpenReacConfig.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/OpenReacConfig.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class OpenReacConfig {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/OpenReacModel.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/OpenReacModel.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 import static com.powsybl.ampl.converter.AmplConstants.DEFAULT_VARIANT_INDEX;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  * OpenReac: a reactive opf to set target tension of the generators.
  * Enumeration to link resources ampl models to java code.
  * It allows to get the list of InputStream of the ampl model resources.

--- a/open-reac/src/main/java/com/powsybl/openreac/OpenReacRunner.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/OpenReacRunner.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public final class OpenReacRunner {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/Reports.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/Reports.java
@@ -11,7 +11,7 @@ import com.powsybl.commons.report.TypedValue;
 import com.powsybl.openreac.parameters.input.algo.OpenReacOptimisationObjective;
 
 /**
- * @author Joris Mancini <joris.mancini_externe at rte-france.com>
+ * @author Joris Mancini {@literal <joris.mancini_externe at rte-france.com>}
  */
 public final class Reports {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/exceptions/IncompatibleModelException.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/exceptions/IncompatibleModelException.java
@@ -11,7 +11,7 @@ import com.powsybl.commons.PowsyblException;
 /**
  * Throw this error when the interface between ampl and java is not correct.
  * This is an internal OpenReac error. It is not the user fault.
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public class IncompatibleModelException extends PowsyblException {
     public IncompatibleModelException(String message) {

--- a/open-reac/src/main/java/com/powsybl/openreac/exceptions/InvalidParametersException.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/exceptions/InvalidParametersException.java
@@ -9,7 +9,7 @@ package com.powsybl.openreac.exceptions;
 import com.powsybl.commons.PowsyblException;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public class InvalidParametersException extends PowsyblException {
     public InvalidParametersException(String message) {

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/AmplIOUtils.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/AmplIOUtils.java
@@ -11,7 +11,7 @@ import com.powsybl.commons.PowsyblException;
 import java.util.Objects;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public final class AmplIOUtils {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/OpenReacAmplIOFiles.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/OpenReacAmplIOFiles.java
@@ -32,7 +32,7 @@ import java.util.List;
  * However, when adding new inputs (outputs) to OpenReac, one must add {@link AmplInputFile} ({@link AmplOutputFile})
  * here through {@link OpenReacAmplIOFiles#getInputParameters} ({@link OpenReacAmplIOFiles#getOutputParameters})
  *
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public class OpenReacAmplIOFiles implements AmplParameters {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/AbstractElementsInput.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/AbstractElementsInput.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public abstract class AbstractElementsInput implements AmplInputFile {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/ConfiguredBusesWithReactiveSlack.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/ConfiguredBusesWithReactiveSlack.java
@@ -11,7 +11,7 @@ import com.powsybl.ampl.converter.AmplSubset;
 import java.util.List;
 
 /**
- * @author Pierre Arvy <pierre.arvy at artelys.com>
+ * @author Pierre Arvy {@literal <pierre.arvy at artelys.com>}
  */
 public class ConfiguredBusesWithReactiveSlack extends AbstractElementsInput {
     public static final String PARAM_BUSES_FILE_NAME = "param_buses_with_reactive_slack.txt";

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/ConstantQGenerators.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/ConstantQGenerators.java
@@ -11,7 +11,7 @@ import com.powsybl.ampl.converter.AmplSubset;
 import java.util.List;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  *
  * List of generators that are not regulating voltage.
  * timestep num bus id

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
@@ -19,8 +19,8 @@ import java.util.stream.Collectors;
 /**
  * This class stores all inputs parameters specific to the OpenReac optimizer.
  *
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
- * @author Pierre Arvy <pierre.arvy at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
+ * @author Pierre Arvy {@literal <pierre.arvy at artelys.com>}
  */
 public class OpenReacParameters {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/VariableShuntCompensators.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/VariableShuntCompensators.java
@@ -11,7 +11,7 @@ import com.powsybl.ampl.converter.AmplSubset;
 import java.util.List;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  *
  * List of shunts which section that can be modified by OpenReac.
  * timestep num bus id

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/VariableTwoWindingsTransformers.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/VariableTwoWindingsTransformers.java
@@ -10,7 +10,7 @@ import com.powsybl.ampl.converter.AmplSubset;
 import java.util.List;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  *
  * List of transformers of which tap position can be modified by OpenReac.
  */

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/VoltageLevelLimitsOverrideInput.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/VoltageLevelLimitsOverrideInput.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public class VoltageLevelLimitsOverrideInput implements AmplInputFile {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/VoltageLimitOverride.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/VoltageLimitOverride.java
@@ -13,8 +13,8 @@ import java.util.Objects;
 /**
  * Class to store an override of a voltage level voltage limits.
  *
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
- * @author Pierre Arvy <pierre.arvy at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
+ * @author Pierre Arvy {@literal <pierre.arvy at artelys.com>}
  */
 public class VoltageLimitOverride {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/algo/AlgorithmInput.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/algo/AlgorithmInput.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public class AlgorithmInput implements AmplInputFile {
     private static final String ALGORITHM_INPUT_FILE = "param_algo.txt";

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/algo/OpenReacAlgoParam.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/algo/OpenReacAlgoParam.java
@@ -7,7 +7,7 @@
 package com.powsybl.openreac.parameters.input.algo;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public interface OpenReacAlgoParam {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/algo/OpenReacAlgoParamImpl.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/algo/OpenReacAlgoParamImpl.java
@@ -9,7 +9,7 @@ package com.powsybl.openreac.parameters.input.algo;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class OpenReacAlgoParamImpl implements OpenReacAlgoParam {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/algo/OpenReacAmplLogLevel.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/algo/OpenReacAmplLogLevel.java
@@ -7,7 +7,7 @@
 package com.powsybl.openreac.parameters.input.algo;
 
 /**
- * @author Pierre Arvy <pierre.arvy at artelys.com>
+ * @author Pierre Arvy {@literal <pierre.arvy at artelys.com>}
  */
 public enum OpenReacAmplLogLevel {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/algo/OpenReacOptimisationObjective.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/algo/OpenReacOptimisationObjective.java
@@ -9,7 +9,7 @@ package com.powsybl.openreac.parameters.input.algo;
 import com.powsybl.openreac.parameters.input.OpenReacParameters;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public enum OpenReacOptimisationObjective {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/algo/OpenReacSolverLogLevel.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/algo/OpenReacSolverLogLevel.java
@@ -7,7 +7,7 @@
 package com.powsybl.openreac.parameters.input.algo;
 
 /**
- * @author Pierre Arvy <pierre.arvy at artelys.com>
+ * @author Pierre Arvy {@literal <pierre.arvy at artelys.com>}
  */
 public enum OpenReacSolverLogLevel {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/algo/ReactiveSlackBusesMode.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/algo/ReactiveSlackBusesMode.java
@@ -7,7 +7,7 @@
 package com.powsybl.openreac.parameters.input.algo;
 
 /**
- * @author Pierre Arvy <pierre.arvy at artelys.com>
+ * @author Pierre Arvy {@literal <pierre.arvy at artelys.com>}
  */
 public enum ReactiveSlackBusesMode {
     CONFIGURED("CONFIGURED"),

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/json/OpenReacAlgoParamDeserializer.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/json/OpenReacAlgoParamDeserializer.java
@@ -16,7 +16,7 @@ import com.powsybl.openreac.parameters.input.algo.OpenReacAlgoParamImpl;
 import java.io.IOException;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class OpenReacAlgoParamDeserializer extends StdDeserializer<OpenReacAlgoParam> {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/json/OpenReacAlgoParamSerializer.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/json/OpenReacAlgoParamSerializer.java
@@ -14,7 +14,7 @@ import com.powsybl.openreac.parameters.input.algo.OpenReacAlgoParam;
 import java.io.IOException;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class OpenReacAlgoParamSerializer extends StdSerializer<OpenReacAlgoParam> {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/json/OpenReacParametersDeserializer.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/json/OpenReacParametersDeserializer.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 
 public class OpenReacParametersDeserializer extends StdDeserializer<OpenReacParameters> {

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/json/OpenReacParametersSerializer.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/json/OpenReacParametersSerializer.java
@@ -15,7 +15,7 @@ import com.powsybl.openreac.parameters.input.algo.ReactiveSlackBusesMode;
 import java.io.IOException;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class OpenReacParametersSerializer extends StdSerializer<OpenReacParameters> {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/json/OpenReactJsonModule.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/json/OpenReactJsonModule.java
@@ -12,7 +12,7 @@ import com.powsybl.openreac.parameters.input.VoltageLimitOverride;
 import com.powsybl.openreac.parameters.input.algo.OpenReacAlgoParam;
 
 /**
- * @author Hugo Marcellin <hugo.marcelin at rte-france.com>
+ * @author Hugo Marcellin {@literal <hugo.marcelin at rte-france.com>}
  */
 
 public class OpenReactJsonModule extends SimpleModule {

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/json/VoltageLimitOverrideDeserializer.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/json/VoltageLimitOverrideDeserializer.java
@@ -16,7 +16,7 @@ import com.powsybl.openreac.parameters.input.VoltageLimitOverride;
 import java.io.IOException;
 
 /**
- * @author Hugo Marcellin <hugo.marcelin at rte-france.com>
+ * @author Hugo Marcellin {@literal <hugo.marcelin at rte-france.com>}
  */
 
 public class VoltageLimitOverrideDeserializer extends StdDeserializer<VoltageLimitOverride> {

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/json/VoltageLimitOverrideSerializer.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/json/VoltageLimitOverrideSerializer.java
@@ -14,7 +14,7 @@ import com.powsybl.openreac.parameters.input.VoltageLimitOverride;
 import java.io.IOException;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 
 public class VoltageLimitOverrideSerializer extends StdSerializer<VoltageLimitOverride> {

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/output/AbstractNoThrowOutput.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/output/AbstractNoThrowOutput.java
@@ -18,7 +18,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public abstract class AbstractNoThrowOutput implements NoThrowAmplOutput {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/output/NoThrowAmplOutput.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/output/NoThrowAmplOutput.java
@@ -17,7 +17,7 @@ import java.io.IOException;
  * Interface for output ampl files, which changes the behavior of errors during file reading.
  * <p>
  * Removes the contract of {@link AmplOutputFile} to throw IOException.
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public interface NoThrowAmplOutput extends AmplOutputFile {
     /**

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/output/OpenReacResult.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/output/OpenReacResult.java
@@ -21,7 +21,7 @@ import java.util.*;
 /**
  * OpenReac user interface to get results information.
  *
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public class OpenReacResult {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/output/OpenReacStatus.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/output/OpenReacStatus.java
@@ -7,7 +7,7 @@
 package com.powsybl.openreac.parameters.output;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public enum OpenReacStatus {
     /**

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/output/ReactiveSlackOutput.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/output/ReactiveSlackOutput.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  * Reactive slacks in load convention.
  */
 public class ReactiveSlackOutput extends AbstractNoThrowOutput {

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/output/VoltageProfileOutput.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/output/VoltageProfileOutput.java
@@ -14,7 +14,7 @@ import org.jgrapht.alg.util.Pair;
 import java.util.*;
 
 /**
- * @author Pierre Arvy <pierre.arvy at artelys.com>
+ * @author Pierre Arvy {@literal <pierre.arvy at artelys.com>}
  */
 public class VoltageProfileOutput extends AbstractNoThrowOutput {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/output/network/AbstractNetworkOutput.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/output/network/AbstractNetworkOutput.java
@@ -17,7 +17,7 @@ import java.util.List;
  * Abstract class that reads output from ampl and generates network modifications
  *
  * @param <T> The type of modification read in the output file
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public abstract class AbstractNetworkOutput<T extends NetworkModification> extends AbstractNoThrowOutput {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/output/network/GeneratorNetworkOutput.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/output/network/GeneratorNetworkOutput.java
@@ -12,7 +12,7 @@ import com.powsybl.iidm.modification.GeneratorModification;
 import com.powsybl.iidm.network.Network;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public class GeneratorNetworkOutput extends AbstractNetworkOutput<GeneratorModification> {
     private static final String ELEMENT = "generators";

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/output/network/NetworkModifications.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/output/network/NetworkModifications.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 /**
  * Data class to store all outputs resulting of NetworkModification.
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public class NetworkModifications {
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/output/network/ShuntCompensatorNetworkOutput.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/output/network/ShuntCompensatorNetworkOutput.java
@@ -13,7 +13,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.ShuntCompensator;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public class ShuntCompensatorNetworkOutput extends AbstractNetworkOutput<ShuntCompensatorModification> {
     private static final String ELEMENT = "shunts";

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/output/network/SvcNetworkOutput.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/output/network/SvcNetworkOutput.java
@@ -13,7 +13,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.StaticVarCompensator;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public class SvcNetworkOutput extends AbstractNetworkOutput<StaticVarCompensatorModification> {
     private static final String ELEMENT = "static_var_compensators";

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/output/network/TapPositionNetworkOutput.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/output/network/TapPositionNetworkOutput.java
@@ -14,7 +14,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public class TapPositionNetworkOutput extends AbstractNetworkOutput<RatioTapPositionModification> {
     private static final String ELEMENT = "rtc";

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/output/network/VscNetworkOutput.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/output/network/VscNetworkOutput.java
@@ -13,7 +13,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VscConverterStation;
 
 /**
- * @author Nicolas Pierre <nicolas.pierre at artelys.com>
+ * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  */
 public class VscNetworkOutput extends AbstractNetworkOutput<VscConverterStationModification> {
     private static final String ELEMENT = "vsc_converter_stations";

--- a/open-reac/src/test/java/com/powsybl/openreac/OpenReacParametersTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/OpenReacParametersTest.java
@@ -23,8 +23,8 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Nicolas PIERRE <nicolas.pierre at artelys.com>
- * @author Pierre ARVY <pierre.arvy at artelys.com>
+ * @author Nicolas PIERRE {@literal <nicolas.pierre at artelys.com>}
+ * @author Pierre ARVY {@literal <pierre.arvy at artelys.com>}
  */
 public class OpenReacParametersTest {
 

--- a/open-reac/src/test/java/com/powsybl/openreac/OpenReacResultsTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/OpenReacResultsTest.java
@@ -24,6 +24,9 @@ import java.util.HashMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+/**
+ * @author Pierre Arvy {@literal <pierre.arvy at artelys.com>}
+ */
 class OpenReacResultsTest {
 
     @Test

--- a/open-reac/src/test/java/com/powsybl/openreac/OpenReacRunnerTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/OpenReacRunnerTest.java
@@ -44,8 +44,8 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
- * @author Nicolas PIERRE <nicolas.pierre at artelys.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
+ * @author Nicolas PIERRE {@literal <nicolas.pierre at artelys.com>}
  */
 class OpenReacRunnerTest {
     protected FileSystem fileSystem;

--- a/open-reac/src/test/java/com/powsybl/openreac/TestLocalCommandExecutor.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/TestLocalCommandExecutor.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class TestLocalCommandExecutor implements LocalCommandExecutor {
 

--- a/open-reac/src/test/java/com/powsybl/openreac/network/AbstractLoadFlowNetworkFactory.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/network/AbstractLoadFlowNetworkFactory.java
@@ -9,7 +9,7 @@ package com.powsybl.openreac.network;
 import com.powsybl.iidm.network.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractLoadFlowNetworkFactory {
 

--- a/open-reac/src/test/java/com/powsybl/openreac/network/HvdcNetworkFactory.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/network/HvdcNetworkFactory.java
@@ -9,7 +9,7 @@ package com.powsybl.openreac.network;
 import com.powsybl.iidm.network.*;
 
 /**
- * @author Gaël Macherel <gael.macherel@artelys.com>
+ * @author Gaël Macherel {@literal <gael.macherel@artelys.com>}
  */
 public class HvdcNetworkFactory extends AbstractLoadFlowNetworkFactory {
 
@@ -22,7 +22,7 @@ public class HvdcNetworkFactory extends AbstractLoadFlowNetworkFactory {
      * l12          hvdc23
      * </pre>
      *
-     * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
      */
     public static Network createVsc() {
         Network network = Network.create("vsc", "test");
@@ -137,7 +137,7 @@ public class HvdcNetworkFactory extends AbstractLoadFlowNetworkFactory {
      *                              g3
      * </pre>
      *
-     * @author Anne Tilloy <anne.tilloy at rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy at rte-france.com>}
      */
     public static Network createLcc() {
         Network network = Network.create("lcc", "test");
@@ -259,7 +259,7 @@ public class HvdcNetworkFactory extends AbstractLoadFlowNetworkFactory {
      *                                                  g3
      * </pre>
      *
-     * @author Gael Macherel <gael.macherel at artelys.com>
+ * @author Gael Macherel {@literal <gael.macherel at artelys.com>}
      */
     public static Network createLccWithBiggerComponents() {
         Network network = createLcc();

--- a/open-reac/src/test/java/com/powsybl/openreac/network/ShuntNetworkFactory.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/network/ShuntNetworkFactory.java
@@ -12,7 +12,7 @@ import com.powsybl.iidm.network.TopologyKind;
 import com.powsybl.iidm.network.VoltageLevel;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class ShuntNetworkFactory {
 

--- a/open-reac/src/test/java/com/powsybl/openreac/network/VoltageControlNetworkFactory.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/network/VoltageControlNetworkFactory.java
@@ -9,7 +9,7 @@ package com.powsybl.openreac.network;
 import com.powsybl.iidm.network.*;
 
 /**
- * @author Anne Tilloy <anne.tilloy@rte-france.com>
+ * @author Anne Tilloy {@literal <anne.tilloy@rte-france.com>}
  */
 public class VoltageControlNetworkFactory extends AbstractLoadFlowNetworkFactory {
 

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/input/VoltageLevelLimitsOverrideInputTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/input/VoltageLevelLimitsOverrideInputTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class VoltageLevelLimitsOverrideInputTest {
 

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/input/VoltageLimitsOverrideTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/input/VoltageLimitsOverrideTest.java
@@ -11,6 +11,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * @author Pierre Arvy {@literal <pierre.arvy at artelys.com>}
+ */
 class VoltageLimitsOverrideTest {
 
     @Test

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/input/json/OpenReacJsonModuleTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/input/json/OpenReacJsonModuleTest.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class OpenReacJsonModuleTest {
 

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/output/OpenReacNetworkOutputTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/output/OpenReacNetworkOutputTest.java
@@ -12,6 +12,9 @@ import java.io.InputStreamReader;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+/**
+ * @author Pierre Arvy {@literal <pierre.arvy at artelys.com>}
+ */
 class OpenReacNetworkOutputTest {
     @Test
     void wrongNumberOfColumnsTest() throws IOException {

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/output/VoltageProfileOutputTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/output/VoltageProfileOutputTest.java
@@ -11,6 +11,9 @@ import java.io.InputStreamReader;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * @author Pierre Arvy {@literal <pierre.arvy at artelys.com>}
+ */
 class VoltageProfileOutputTest {
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem?**
No, but similar to https://github.com/powsybl/powsybl-core/pull/2753

**What kind of change does this PR introduce?**
Bug fix for javadoc generation.

**What is the current behavior?**
Errors related to the author's email address formatting occur when generating the javadoc.
Email addresses were written as `@author Name Surname <author at email.address>`


**What is the new behavior (if this is a feature change)?**
No more errors related to that when generating the javadoc. 
Email addresses are written as `@author Name Surname {@literal <author at email.address>}`
A few missing author mentions were added too.