### PR TITLE
Add concise and detailed logs for missing or inconsistent voltage levels limits.

### DIFF
--- a/open-reac/src/main/java/com/powsybl/openreac/OpenReacRunner.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/OpenReacRunner.java
@@ -71,7 +71,7 @@ public final class OpenReacRunner {
      * @return All information  about the run and possible modifications to apply.
      */
     public static OpenReacResult run(Network network, String variantId, OpenReacParameters parameters, OpenReacConfig config, ComputationManager manager, ReportNode reportNode, AmplExportConfig amplExportConfig) {
-        checkParameters(network, variantId, parameters, config, manager, reportNode);
+        checkParameters(network, variantId, parameters, config, manager, Reports.createParametersIntegrityReporter(reportNode, network.getId()));
         AmplModel reactiveOpf = OpenReacModel.buildModel();
         OpenReacAmplIOFiles amplIoInterface = new OpenReacAmplIOFiles(parameters, amplExportConfig, network, config.isDebug(), Reports.createOpenReacReporter(reportNode, network.getId(), parameters.getObjective()));
         AmplResults run = AmplModelRunner.run(network, variantId, reactiveOpf, manager, amplIoInterface);
@@ -118,6 +118,6 @@ public final class OpenReacRunner {
         Objects.requireNonNull(config);
         Objects.requireNonNull(manager);
         Objects.requireNonNull(reportNode);
-        parameters.checkIntegrity(network);
+        parameters.checkIntegrity(network, reportNode);
     }
 }

--- a/open-reac/src/main/java/com/powsybl/openreac/OpenReacRunner.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/OpenReacRunner.java
@@ -71,7 +71,7 @@ public final class OpenReacRunner {
      * @return All information  about the run and possible modifications to apply.
      */
     public static OpenReacResult run(Network network, String variantId, OpenReacParameters parameters, OpenReacConfig config, ComputationManager manager, ReportNode reportNode, AmplExportConfig amplExportConfig) {
-        checkParameters(network, variantId, parameters, config, manager, Reports.createParametersIntegrityReporter(reportNode, network.getId()));
+        checkParameters(network, variantId, parameters, config, manager, reportNode);
         AmplModel reactiveOpf = OpenReacModel.buildModel();
         OpenReacAmplIOFiles amplIoInterface = new OpenReacAmplIOFiles(parameters, amplExportConfig, network, config.isDebug(), Reports.createOpenReacReporter(reportNode, network.getId(), parameters.getObjective()));
         AmplResults run = AmplModelRunner.run(network, variantId, reactiveOpf, manager, amplIoInterface);
@@ -118,6 +118,6 @@ public final class OpenReacRunner {
         Objects.requireNonNull(config);
         Objects.requireNonNull(manager);
         Objects.requireNonNull(reportNode);
-        parameters.checkIntegrity(network, reportNode);
+        parameters.checkIntegrity(network, Reports.createParameterIntegrityReporter(reportNode, network.getId()));
     }
 }

--- a/open-reac/src/main/java/com/powsybl/openreac/Reports.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/Reports.java
@@ -51,9 +51,9 @@ public final class Reports {
                 .add();
     }
 
-    public static ReportNode createParametersIntegrityReporter(ReportNode reportNode, String networkId) {
+    public static ReportNode createParameterIntegrityReporter(ReportNode reportNode, String networkId) {
         return reportNode.newReportNode()
-            .withMessageTemplate("openReacParametersIntegrity", "Open reac parameters integrity on network '${networkId}'")
+            .withMessageTemplate("openReacParameterIntegrity", "Open reac parameter integrity on network '${networkId}'")
             .withUntypedValue("networkId", networkId)
             .add();
     }

--- a/open-reac/src/main/java/com/powsybl/openreac/Reports.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/Reports.java
@@ -50,4 +50,12 @@ public final class Reports {
                 .withUntypedValue("size", variableShuntCompensatorsSize)
                 .add();
     }
+
+    public static ReportNode createParametersIntegrityReporter(ReportNode reportNode, String networkId) {
+        return reportNode.newReportNode()
+            .withMessageTemplate("openReacParametersIntegrity", "Open reac parameters integrity on network '${networkId}'")
+            .withUntypedValue("networkId", networkId)
+            .add();
+    }
+
 }

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
@@ -6,15 +6,17 @@
  */
 package com.powsybl.openreac.parameters.input;
 
+import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.TypedValue;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.openreac.exceptions.InvalidParametersException;
 import com.powsybl.openreac.parameters.input.algo.*;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * This class stores all inputs parameters specific to the OpenReac optimizer.
@@ -536,10 +538,14 @@ public class OpenReacParameters {
     /**
      * Do some checks on the parameters given, such as provided IDs must correspond to the given network element
      *
-     * @param network Network on which ID are going to be infered
+     * @param network     Network on which ID are going to be infered
+     * @param reportNode  aggregates functional logging
      * @throws InvalidParametersException if the parameters contain some incoherences.
      */
-    public void checkIntegrity(Network network) throws InvalidParametersException {
+    public void checkIntegrity(Network network, ReportNode reportNode) throws InvalidParametersException {
+        Map<String, Pair<Integer, Integer>> voltageLevelsWithMissingLimits = new TreeMap<>();
+        Map<String, Pair<Double, Double>> voltageLevelsWithInconsistentLimits = new TreeMap<>();
+
         for (String shuntId : getVariableShuntCompensators()) {
             if (network.getShuntCompensator(shuntId) == null) {
                 throw new InvalidParametersException("Shunt " + shuntId + " not found in the network.");
@@ -562,22 +568,69 @@ public class OpenReacParameters {
         }
 
         // Check integrity of voltage overrides
-        boolean integrityVoltageLimitOverrides = checkVoltageLimitOverrides(network);
-        if (!integrityVoltageLimitOverrides) {
-            throw new InvalidParametersException("At least one voltage limit override is inconsistent.");
-        }
+        boolean integrityVoltageLimitOverrides = checkVoltageLimitOverrides(network, voltageLevelsWithInconsistentLimits);
 
         // Check integrity of low/high voltage limits, taking into account voltage limit overrides
-        boolean integrityVoltageLevelLimits = checkLowVoltageLevelLimits(network);
-        integrityVoltageLevelLimits &= checkHighVoltageLevelLimits(network);
-        if (!integrityVoltageLevelLimits) {
-            throw new InvalidParametersException("At least one voltage level has an undefined or incorrect voltage limit.");
+        boolean integrityVoltageLevelLimits = checkLowVoltageLevelLimits(network, voltageLevelsWithMissingLimits);
+        integrityVoltageLevelLimits &= checkHighVoltageLevelLimits(network, voltageLevelsWithMissingLimits);
+
+        if (!integrityVoltageLevelLimits || !integrityVoltageLimitOverrides) {
+            if (!voltageLevelsWithMissingLimits.isEmpty()) {
+                reportNode.newReportNode()
+                    .withMessageTemplate("nbVoltageLevelsWithMissingLimits", "${size} voltage level(s) have undefined low and/or high voltage limits")
+                    .withSeverity(TypedValue.INFO_SEVERITY)
+                    .withUntypedValue("size", voltageLevelsWithMissingLimits.size())
+                    .add();
+                voltageLevelsWithMissingLimits.forEach((key, value) -> {
+                    String messageSuffix = "has undefined low and high voltage limits";
+                    if (value.getLeft() == 0) {
+                        messageSuffix = "has undefined high voltage limit";
+                    } else if (value.getRight() == 0) {
+                        messageSuffix = "has undefined low voltage limit";
+                    }
+                    reportNode.newReportNode()
+                        .withMessageTemplate("voltageLevelWithMissingLimits", "${vlId} " + messageSuffix)
+                        .withSeverity(TypedValue.TRACE_SEVERITY)
+                        .withUntypedValue("vlId", key)
+                        .add();
+                });
+            }
+            if (!voltageLevelsWithInconsistentLimits.isEmpty()) {
+                reportNode.newReportNode()
+                    .withMessageTemplate("nbVoltageLevelsWithInconsistentLimits", "${size} voltage level(s) have inconsistent low and/or high voltage limits")
+                    .withSeverity(TypedValue.INFO_SEVERITY)
+                    .withUntypedValue("size", voltageLevelsWithInconsistentLimits.size())
+                    .add();
+                voltageLevelsWithInconsistentLimits.forEach((key, value) -> reportNode.newReportNode()
+                    .withMessageTemplate("voltageLevelWithInconsistentLimits", "${vlId} has one or two inconsistent voltage limits (low voltage limit = ${low}, high voltage limit = ${high})")
+                    .withSeverity(TypedValue.TRACE_SEVERITY)
+                    .withUntypedValue("vlId", key)
+                    .withUntypedValue("low", value.getLeft())
+                    .withUntypedValue("high", value.getRight())
+                    .add());
+            }
+
+            if (!integrityVoltageLevelLimits) {
+                throw new InvalidParametersException("At least one voltage level has an undefined or incorrect voltage limit.");
+            } else {
+                throw new InvalidParametersException("At least one voltage limit override is inconsistent.");
+            }
         }
 
         boolean integrityAlgorithmParameters = checkAlgorithmParametersIntegrity();
         if (!integrityAlgorithmParameters) {
             throw new InvalidParametersException("At least one algorithm parameter is inconsistent.");
         }
+    }
+
+    /**
+     * Do some checks on the parameters given, such as provided IDs must correspond to the given network element
+     *
+     * @param network Network on which ID are going to be infered
+     * @throws InvalidParametersException if the parameters contain some incoherences.
+     */
+    public void checkIntegrity(Network network) throws InvalidParametersException {
+        checkIntegrity(network, ReportNode.NO_OP);
     }
 
     /**
@@ -628,7 +681,7 @@ public class OpenReacParameters {
      * @return true if the low voltage level limits are correct taking into account low voltage limit overrides,
      * false otherwise.
      */
-    boolean checkLowVoltageLevelLimits(Network network) {
+    boolean checkLowVoltageLevelLimits(Network network, Map<String, Pair<Integer, Integer>> voltageLevelsWithMissingLimits) {
         boolean integrityVoltageLevelLimits = true;
 
         for (VoltageLevel vl : network.getVoltageLevels()) {
@@ -637,9 +690,11 @@ public class OpenReacParameters {
             if (Double.isNaN(lowLimit)) {
                 List<VoltageLimitOverride> overrides = getSpecificVoltageLimits(vl.getId(), VoltageLimitOverride.VoltageLimitType.LOW_VOLTAGE_LIMIT);
                 if (overrides.size() != 1) {
+                    voltageLevelsWithMissingLimits.merge(vl.getId(), Pair.of(1, 0), (old, value) -> Pair.of(old.getLeft() + 1, old.getRight()));
                     LOGGER.warn("Voltage level {} has no low voltage limit defined. Please add one or use a voltage limit override.", vl.getId());
                     integrityVoltageLevelLimits = false;
                 } else if (overrides.get(0).isRelative()) { // we have one and just one
+                    voltageLevelsWithMissingLimits.merge(vl.getId(), Pair.of(1, 0), (old, value) -> Pair.of(old.getLeft() + 1, old.getRight()));
                     LOGGER.warn("Relative voltage override impossible on undefined low voltage limit for voltage level {}.", vl.getId());
                     integrityVoltageLevelLimits = false;
                 }
@@ -655,7 +710,7 @@ public class OpenReacParameters {
      * @return true if the high voltage level limits are correct taking into account high voltage limit overrides,
      * false otherwise.
      */
-    boolean checkHighVoltageLevelLimits(Network network) {
+    boolean checkHighVoltageLevelLimits(Network network, Map<String, Pair<Integer, Integer>> voltageLevelsWithMissingLimits) {
         boolean integrityVoltageLevelLimits = true;
 
         for (VoltageLevel vl : network.getVoltageLevels()) {
@@ -664,9 +719,11 @@ public class OpenReacParameters {
             if (Double.isNaN(highLimit)) {
                 List<VoltageLimitOverride> overrides = getSpecificVoltageLimits(vl.getId(), VoltageLimitOverride.VoltageLimitType.HIGH_VOLTAGE_LIMIT);
                 if (overrides.size() != 1) {
+                    voltageLevelsWithMissingLimits.merge(vl.getId(), Pair.of(0, 1), (old, value) -> Pair.of(old.getLeft(), old.getRight() + 1));
                     LOGGER.warn("Voltage level {} has no high voltage limit defined. Please add one or use a voltage limit override.", vl.getId());
                     integrityVoltageLevelLimits = false;
                 } else if (overrides.get(0).isRelative()) {
+                    voltageLevelsWithMissingLimits.merge(vl.getId(), Pair.of(0, 1), (old, value) -> Pair.of(old.getLeft(), old.getRight() + 1));
                     LOGGER.warn("Relative voltage override impossible on undefined high voltage limit for voltage level {}.", vl.getId());
                     integrityVoltageLevelLimits = false;
                 }
@@ -681,8 +738,11 @@ public class OpenReacParameters {
      * @param network the network on which are applied voltage limit overrides.
      * @return true if the integrity of voltage limit overrides is verified, false otherwise.
      */
-    boolean checkVoltageLimitOverrides(Network network) {
+    boolean checkVoltageLimitOverrides(Network network,
+                                       Map<String, Pair<Double, Double>> voltageLevelsWithInconsistentLimits) {
         // Check integrity of voltage overrides
+        Map<String, Pair<Double, Double>> voltageLevelsLimitsAfterOverride = new HashMap<>();
+
         boolean integrityVoltageLimitOverrides = true;
         for (VoltageLimitOverride voltageLimitOverride : getSpecificVoltageLimits()) {
             String voltageLevelId = voltageLimitOverride.getVoltageLevelId();
@@ -697,25 +757,56 @@ public class OpenReacParameters {
 
             if (voltageLimitOverride.isRelative()) {
                 double value = voltageLimitOverride.getVoltageLimitType() == VoltageLimitOverride.VoltageLimitType.LOW_VOLTAGE_LIMIT ?
-                        voltageLevel.getLowVoltageLimit() : voltageLevel.getHighVoltageLimit();
+                    voltageLevel.getLowVoltageLimit() : voltageLevel.getHighVoltageLimit();
                 if (Double.isNaN(value)) {
                     LOGGER.warn("Voltage level {} has undefined {}, relative voltage limit override is impossible.",
-                            voltageLevelId, voltageLimitOverride.getVoltageLimitType());
+                        voltageLevelId, voltageLimitOverride.getVoltageLimitType());
                     integrityVoltageLimitOverrides = false;
+                    continue;
                 }
                 // verify voltage limit override does not lead to negative limit value
-                if (value + voltageLimitOverride.getLimit() < 0) {
+                double valueAfter = value + voltageLimitOverride.getLimit();
+                if (voltageLimitOverride.getVoltageLimitType() == VoltageLimitOverride.VoltageLimitType.LOW_VOLTAGE_LIMIT) {
+                    voltageLevelsLimitsAfterOverride.merge(voltageLevelId, Pair.of(valueAfter, voltageLevel.getHighVoltageLimit()), (old, newValue) -> Pair.of(valueAfter, old.getRight()));
+                    if (valueAfter < 0) {
+                        voltageLevelsWithInconsistentLimits.merge(voltageLevelId, Pair.of(valueAfter, voltageLevel.getHighVoltageLimit()), (old, newValue) -> Pair.of(valueAfter, old.getRight()));
+                    }
+                } else {
+                    voltageLevelsLimitsAfterOverride.merge(voltageLevelId, Pair.of(voltageLevel.getLowVoltageLimit(), valueAfter), (old, newValue) -> Pair.of(old.getLeft(), valueAfter));
+                    if (valueAfter < 0) {
+                        voltageLevelsWithInconsistentLimits.merge(voltageLevelId, Pair.of(voltageLevel.getLowVoltageLimit(), valueAfter), (old, newValue) -> Pair.of(old.getLeft(), valueAfter));
+                    }
+                }
+                if (valueAfter < 0) {
                     LOGGER.warn("Voltage level {} relative override leads to a negative {}.",
-                            voltageLevelId, voltageLimitOverride.getVoltageLimitType());
+                        voltageLevelId, voltageLimitOverride.getVoltageLimitType());
+                    integrityVoltageLimitOverrides = false;
+                }
+            } else {
+                if (voltageLimitOverride.getVoltageLimitType() == VoltageLimitOverride.VoltageLimitType.LOW_VOLTAGE_LIMIT) {
+                    voltageLevelsLimitsAfterOverride.merge(voltageLevelId, Pair.of(voltageLimitOverride.getLimit(), voltageLevel.getHighVoltageLimit()), (old, newValue) -> Pair.of(voltageLimitOverride.getLimit(), old.getRight()));
+                } else {
+                    voltageLevelsLimitsAfterOverride.merge(voltageLevelId, Pair.of(voltageLevel.getLowVoltageLimit(), voltageLimitOverride.getLimit()), (old, newValue) -> Pair.of(old.getLeft(), voltageLimitOverride.getLimit()));
+                }
+            }
+        }
+
+        // check low limit is lower than high limit after overrides
+        if (integrityVoltageLimitOverrides) {
+            for (Map.Entry<String, Pair<Double, Double>> entry : voltageLevelsLimitsAfterOverride.entrySet()) {
+                String vlId = entry.getKey();
+                if (entry.getValue().getLeft() > entry.getValue().getRight()) {
+                    voltageLevelsWithInconsistentLimits.merge(vlId, Pair.of(entry.getValue().getLeft(), entry.getValue().getRight()), (old, newValue) -> Pair.of(entry.getValue().getLeft(), entry.getValue().getRight()));
                     integrityVoltageLimitOverrides = false;
                 }
             }
         }
+
         return integrityVoltageLimitOverrides;
     }
 
     private List<VoltageLimitOverride> getSpecificVoltageLimits(String voltageLevelId, VoltageLimitOverride.VoltageLimitType type) {
         return specificVoltageLimits.stream()
-                .filter(limit -> limit.getVoltageLevelId().equals(voltageLevelId) && limit.getVoltageLimitType() == type).collect(Collectors.toList());
+                .filter(limit -> limit.getVoltageLevelId().equals(voltageLevelId) && limit.getVoltageLimitType() == type).toList();
     }
 }

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/input/VoltageLevelLimitsOverrideInputTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/input/VoltageLevelLimitsOverrideInputTest.java
@@ -157,6 +157,7 @@ class VoltageLevelLimitsOverrideInputTest {
 
         params2.getSpecificVoltageLimits().clear();
         voltageLimitsOverride2.clear();
+        vl.setLowVoltageLimit(0.);
         voltageLimitsOverride2.add(new VoltageLimitOverride(vl.getId(), VoltageLimitOverride.VoltageLimitType.HIGH_VOLTAGE_LIMIT, true, -480));
         params2.addSpecificVoltageLimits(voltageLimitsOverride2);
         assertDoesNotThrow(() -> params2.checkIntegrity(network)); // zero value


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When there are voltage levels without limits, and also when there are inconsistencies in the limits (limit < 0 or low limit > high limit),
an exception is just thrown, and we have no information about the concerned voltage levels.  


**What is the new behavior (if this is a feature change)?**
Synthetic and detailed reports are now created for missing or inconsistent voltage levels limits, before the exception is thrown, in order to help the user to correct his data.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
