### PR TITLE
G/B to 0 for non-impedant branches in AMPL

### DIFF
--- a/open-reac/src/main/resources/openreac/acopf.mod
+++ b/open-reac/src/main/resources/openreac/acopf.mod
@@ -109,27 +109,27 @@ var branch_Ror_var{(qq,m,n) in BRANCHCC_REGL_VAR}
 var Red_Tran_Act_Dir{(qq,m,n) in BRANCHCC } =
     V[n] * branch_admi[qq,m,n] * sin(teta[m]-teta[n]+branch_dephor[qq,m,n]-branch_angper[qq,m,n])
     * (if (qq,m,n) in BRANCHCC_REGL_VAR then branch_Ror_var[qq,m,n]*branch_cstratio[1,qq,m,n] else branch_Ror[qq,m,n])
-  + V[m] * (branch_admi[qq,m,n]*sin(branch_angper[qq,m,n])+branch_Gor[1,qq,m,n])
+  + V[m] * (branch_admi[qq,m,n]*sin(branch_angper[qq,m,n])+branch_Gor_mod[qq,m,n])
     * (if (qq,m,n) in BRANCHCC_REGL_VAR then branch_Ror_var[qq,m,n]*branch_cstratio[1,qq,m,n] else branch_Ror[qq,m,n])**2
   ;
 
 var Red_Tran_Rea_Dir{(qq,m,n) in BRANCHCC } =
   - V[n] * branch_admi[qq,m,n] * cos(teta[m]-teta[n]+branch_dephor[qq,m,n]-branch_angper[qq,m,n])
     * (if (qq,m,n) in BRANCHCC_REGL_VAR then branch_Ror_var[qq,m,n]*branch_cstratio[1,qq,m,n] else branch_Ror[qq,m,n])
-  + V[m] * (branch_admi[qq,m,n]*cos(branch_angper[qq,m,n])-branch_Bor[1,qq,m,n])
+  + V[m] * (branch_admi[qq,m,n]*cos(branch_angper[qq,m,n])-branch_Bor_mod[qq,m,n])
     * (if (qq,m,n) in BRANCHCC_REGL_VAR then branch_Ror_var[qq,m,n]*branch_cstratio[1,qq,m,n] else branch_Ror[qq,m,n])^2
   ;
 
 var Red_Tran_Act_Inv{(qq,m,n) in BRANCHCC } =
     V[m] * branch_admi[qq,m,n] * sin(teta[n]-teta[m]-branch_dephor[qq,m,n]-branch_angper[qq,m,n])
     * (if (qq,m,n) in BRANCHCC_REGL_VAR then branch_Ror_var[qq,m,n]*branch_cstratio[1,qq,m,n] else branch_Ror[qq,m,n])
-  + V[n] * (branch_admi[qq,m,n]*sin(branch_angper[qq,m,n])+branch_Gex[1,qq,m,n])
+  + V[n] * (branch_admi[qq,m,n]*sin(branch_angper[qq,m,n])+branch_Gex_mod[qq,m,n])
   ;
 
 var Red_Tran_Rea_Inv{(qq,m,n) in BRANCHCC } =
   - V[m] * branch_admi[qq,m,n] * cos(teta[n]-teta[m]-branch_dephor[qq,m,n]-branch_angper[qq,m,n])
     * (if (qq,m,n) in BRANCHCC_REGL_VAR then branch_Ror_var[qq,m,n]*branch_cstratio[1,qq,m,n] else branch_Ror[qq,m,n])
-  + V[n] * (branch_admi[qq,m,n]*cos(branch_angper[qq,m,n])-branch_Bex[1,qq,m,n])
+  + V[n] * (branch_admi[qq,m,n]*cos(branch_angper[qq,m,n])-branch_Bex_mod[qq,m,n])
   ;
 
 

--- a/open-reac/src/main/resources/openreac/commons.mod
+++ b/open-reac/src/main/resources/openreac/commons.mod
@@ -103,6 +103,23 @@ param branch_X_mod{(qq,m,n) in BRANCHCC} :=
   else branch_X[1,qq,m,n];
 check {(qq,m,n) in BRANCHCC}: abs(branch_X_mod[qq,m,n]) > 0;
 
+# If in BRANCHZNULL, then set Gor/Gex/Bor/Bex to 0
+param branch_Gor_mod{(qq,m,n) in BRANCHCC} :=
+    if (qq,m,n) in BRANCHZNULL then 0
+    else branch_Gor[1,qq,m,n];
+
+param branch_Gex_mod{(qq,m,n) in BRANCHCC} :=
+    if (qq,m,n) in BRANCHZNULL then 0
+    else branch_Gex[1,qq,m,n];
+
+param branch_Bor_mod{(qq,m,n) in BRANCHCC} :=
+    if (qq,m,n) in BRANCHZNULL then 0
+    else branch_Bor[1,qq,m,n];
+
+param branch_Bex_mod{(qq,m,n) in BRANCHCC} :=
+    if (qq,m,n) in BRANCHZNULL then 0
+    else branch_Bex[1,qq,m,n];
+
 # Busses with valid voltage value
 set BUSVV := {n in BUSCC : bus_V0[1,n] >= min_plausible_low_voltage_limit};
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
The conductance/susceptance of the non-impedant branches are set to 0.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
These values are used as such for the non-impedant branches. Some values are huge due to per unitage.


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
