### PR TITLE
Fix message key in reports for voltage levels missing limits

### DIFF
--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
@@ -594,14 +594,17 @@ public class OpenReacParameters {
                     .withUntypedValue("size", voltageLevelsWithMissingLimits.size())
                     .add();
                 voltageLevelsWithMissingLimits.forEach((key, value) -> {
+                    String messageKey = "voltageLevelWithBothMissingLimits";
                     String messageSuffix = "has undefined low and high voltage limits";
                     if (value.getLeft() == 0) {
+                        messageKey = "voltageLevelWithHighMissingLimits";
                         messageSuffix = "has undefined high voltage limit";
                     } else if (value.getRight() == 0) {
+                        messageKey = "voltageLevelWithLowMissingLimits";
                         messageSuffix = "has undefined low voltage limit";
                     }
                     reportNode.newReportNode()
-                        .withMessageTemplate("voltageLevelWithMissingLimits", "${vlId} " + messageSuffix)
+                        .withMessageTemplate(messageKey, "${vlId} " + messageSuffix)
                         .withSeverity(TypedValue.TRACE_SEVERITY)
                         .withUntypedValue("vlId", key)
                         .add();

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
@@ -594,13 +594,13 @@ public class OpenReacParameters {
                     .withUntypedValue("size", voltageLevelsWithMissingLimits.size())
                     .add();
                 voltageLevelsWithMissingLimits.forEach((key, value) -> {
-                    String messageKey = "voltageLevelWithBothMissingLimits";
+                    String messageKey = "voltageLevelWithBothLimitsMissing";
                     String messageSuffix = "has undefined low and high voltage limits";
                     if (value.getLeft() == 0) {
-                        messageKey = "voltageLevelWithHighMissingLimits";
+                        messageKey = "voltageLevelWithUpperLimitMissing";
                         messageSuffix = "has undefined high voltage limit";
                     } else if (value.getRight() == 0) {
-                        messageKey = "voltageLevelWithLowMissingLimits";
+                        messageKey = "voltageLevelWithLowerLimitMissing";
                         messageSuffix = "has undefined low voltage limit";
                     }
                     reportNode.newReportNode()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The same message key is used when reporting missing voltage limits in all cases (missing high limits, missing low limits or missing high and low limits).


**What is the new behavior (if this is a feature change)?**
We use now a specific distinct message key for missing high limits, missing low limits or missing high and low limits.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
