### PR TITLE
Add checks on voltage levels limits against the required nominal voltage range

### DIFF
--- a/docs/optimizer/inputs.md
+++ b/docs/optimizer/inputs.md
@@ -65,3 +65,7 @@ In addition to the elements specified in section [Configuration of the run](#con
 
 Format of `ampl_network_substations_override.txt`: 4 columns  
 \#"num" "minV (pu)" "maxV (pu)" "id"
+
+When overriding the voltage limits, checks are also done to verify, for each voltage level, that "minV (kV)" and "maxV (kV)" are in the following range : $[0.85 * Vnom - 5, 1.15 * Vnom + 5]$
+
+If it's not the case, reports are created to indicate the number of voltage levels concerned, and the detailed information for each of these voltage levels.

--- a/open-reac/src/main/java/com/powsybl/openreac/Reports.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/Reports.java
@@ -8,6 +8,7 @@ package com.powsybl.openreac;
 
 import com.powsybl.commons.report.ReportNode;
 import com.powsybl.commons.report.TypedValue;
+import com.powsybl.openreac.parameters.input.VoltageLevelLimitInfo;
 import com.powsybl.openreac.parameters.input.algo.OpenReacOptimisationObjective;
 import com.powsybl.openreac.parameters.output.network.ShuntCompensatorNetworkOutput;
 
@@ -15,6 +16,7 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * @author Joris Mancini {@literal <joris.mancini_externe at rte-france.com>}
@@ -22,7 +24,7 @@ import java.util.Locale;
 public final class Reports {
 
     private static final String NETWORK_ID = "networkId";
-    private static final DecimalFormat REACTIVE_VALUE_FORMAT = new DecimalFormat("0.0", DecimalFormatSymbols.getInstance(Locale.ROOT));
+    private static final DecimalFormat VALUE_FORMAT = new DecimalFormat("0.0", DecimalFormatSymbols.getInstance(Locale.ROOT));
 
     private Reports() {
         // Should not be instantiated
@@ -30,34 +32,34 @@ public final class Reports {
 
     public static ReportNode createOpenReacReporter(ReportNode reportNode, String networkId, OpenReacOptimisationObjective objective) {
         return reportNode.newReportNode()
-                .withMessageTemplate("openReac", "Open Reac on network '${networkId}' with ${objective} objective")
-                .withUntypedValue(NETWORK_ID, networkId)
-                .withUntypedValue("objective", objective.toString())
-                .add();
+            .withMessageTemplate("openReac", "Open Reac on network '${networkId}' with ${objective} objective")
+            .withUntypedValue(NETWORK_ID, networkId)
+            .withUntypedValue("objective", objective.toString())
+            .add();
     }
 
     public static void reportConstantQGeneratorsSize(ReportNode reportNode, int constantQGeneratorsSize) {
         reportNode.newReportNode()
-                .withMessageTemplate("constantQGeneratorsSize", "Reactive power target is considered fixed for ${size} generators")
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .withUntypedValue("size", constantQGeneratorsSize)
-                .add();
+            .withMessageTemplate("constantQGeneratorsSize", "Reactive power target is considered fixed for ${size} generators")
+            .withSeverity(TypedValue.INFO_SEVERITY)
+            .withUntypedValue("size", constantQGeneratorsSize)
+            .add();
     }
 
     public static void reportVariableTwoWindingsTransformersSize(ReportNode reportNode, int variableTwoWindingsTransformersSize) {
         reportNode.newReportNode()
-                .withMessageTemplate("variableTwoWindingsTransformersSize", "There are ${size} two-winding transformers with tap position considered as variable")
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .withUntypedValue("size", variableTwoWindingsTransformersSize)
-                .add();
+            .withMessageTemplate("variableTwoWindingsTransformersSize", "There are ${size} two-winding transformers with tap position considered as variable")
+            .withSeverity(TypedValue.INFO_SEVERITY)
+            .withUntypedValue("size", variableTwoWindingsTransformersSize)
+            .add();
     }
 
     public static void reportVariableShuntCompensatorsSize(ReportNode reportNode, int variableShuntCompensatorsSize) {
         reportNode.newReportNode()
-                .withMessageTemplate("variableShuntCompensatorsSize", "There are ${size} shunt compensators with section considered as variable")
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .withUntypedValue("size", variableShuntCompensatorsSize)
-                .add();
+            .withMessageTemplate("variableShuntCompensatorsSize", "There are ${size} shunt compensators with section considered as variable")
+            .withSeverity(TypedValue.INFO_SEVERITY)
+            .withUntypedValue("size", variableShuntCompensatorsSize)
+            .add();
     }
 
     public static ReportNode createParameterIntegrityReporter(ReportNode reportNode, String networkId) {
@@ -84,10 +86,33 @@ public final class Reports {
                     .withMessageTemplate("shuntCompensatorDeltaDiscretizedOptimizedOverThreshold", "After discretization, shunt compensator ${shuntCompensatorId} with ${maxSectionCount} available section(s) has been set to ${discretizedValue} MVar (optimal value : ${optimalValue} MVar)")
                     .withUntypedValue("shuntCompensatorId", shunt.id())
                     .withUntypedValue("maxSectionCount", shunt.maximumSectionCount())
-                    .withUntypedValue("discretizedValue", REACTIVE_VALUE_FORMAT.format(shunt.discretizedReactiveValue()))
-                    .withUntypedValue("optimalValue", REACTIVE_VALUE_FORMAT.format(shunt.optimalReactiveValue()))
+                    .withUntypedValue("discretizedValue", VALUE_FORMAT.format(shunt.discretizedReactiveValue()))
+                    .withUntypedValue("optimalValue", VALUE_FORMAT.format(shunt.optimalReactiveValue()))
                     .withSeverity(TypedValue.TRACE_SEVERITY)
                     .add());
+        }
+    }
+
+    public static void reportVoltageLevelsWithLimitsOutOfNominalVRange(ReportNode reportNode, Map<String, VoltageLevelLimitInfo> voltageLevelsWithLimitsOutOfNominalVRange) {
+        if (!voltageLevelsWithLimitsOutOfNominalVRange.isEmpty()) {
+            ReportNode reportLimitsOutOfRange = reportNode.newReportNode()
+                .withMessageTemplate("voltageLevelsLimitsOutOfNominalVRange", "Voltage levels limits out of nominal voltage range")
+                .add();
+
+            reportLimitsOutOfRange.newReportNode()
+                .withMessageTemplate("nbVoltageLevelsWithLimitsOutOfNominalVRange", "Acceptable voltage range for ${size} voltage levels seems to be inconsistent with nominal voltage")
+                .withSeverity(TypedValue.WARN_SEVERITY)
+                .withUntypedValue("size", voltageLevelsWithLimitsOutOfNominalVRange.size())
+                .add();
+
+            voltageLevelsWithLimitsOutOfNominalVRange.forEach((voltageLevelId, voltageLevelLimitInfo) -> reportLimitsOutOfRange.newReportNode()
+                .withMessageTemplate("voltageLevelWithLimitsOutOfNominalVRange", "Acceptable voltage range for voltage level ${vID} seems to be inconsistent with nominal voltage : low voltage limit = ${lowVoltageLimit} kV, high voltage limit = ${highVoltageLimit} kV, nominal voltage = ${nominalVoltage} kV")
+                .withSeverity(TypedValue.TRACE_SEVERITY)
+                .withUntypedValue("vID", voltageLevelLimitInfo.voltageLevelId())
+                .withUntypedValue("lowVoltageLimit", VALUE_FORMAT.format(voltageLevelLimitInfo.lowLimit()))
+                .withUntypedValue("highVoltageLimit", VALUE_FORMAT.format(voltageLevelLimitInfo.highLimit()))
+                .withUntypedValue("nominalVoltage", voltageLevelLimitInfo.nominalV())
+                .add());
         }
     }
 }

--- a/open-reac/src/main/java/com/powsybl/openreac/Reports.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/Reports.java
@@ -99,6 +99,7 @@ public final class Reports {
                 .withMessageTemplate("voltageLevelsLimitsOutOfNominalVRange", "Voltage levels limits out of nominal voltage range")
                 .add();
 
+            // Do not change this report key "nbVoltageLevelsWithLimitsOutOfNominalVRange", as it is used elsewhere
             reportLimitsOutOfRange.newReportNode()
                 .withMessageTemplate("nbVoltageLevelsWithLimitsOutOfNominalVRange", "Acceptable voltage range for ${size} voltage levels seems to be inconsistent with nominal voltage")
                 .withSeverity(TypedValue.WARN_SEVERITY)

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/OpenReacAmplIOFiles.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/OpenReacAmplIOFiles.java
@@ -55,7 +55,7 @@ public class OpenReacAmplIOFiles implements AmplParameters {
         this.variableShuntCompensators = new VariableShuntCompensators(params.getVariableShuntCompensators());
         this.variableTwoWindingsTransformers = new VariableTwoWindingsTransformers(params.getVariableTwoWindingsTransformers());
         this.algorithmParams = new AlgorithmInput(params.getAllAlgorithmParams());
-        this.voltageLimitsOverride = new VoltageLevelLimitsOverrideInput(params.getSpecificVoltageLimits(), network);
+        this.voltageLimitsOverride = new VoltageLevelLimitsOverrideInput(params.getSpecificVoltageLimits(), network, reportNode);
         this.configuredReactiveSlackBuses = new ConfiguredBusesWithReactiveSlack(params.getConfiguredReactiveSlackBuses());
         this.amplExportConfig = amplExportConfig;
 

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/VoltageLevelLimitInfo.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/VoltageLevelLimitInfo.java
@@ -3,11 +3,12 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 package com.powsybl.openreac.parameters.input;
 
 /**
  * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
  */
-public record VoltageLevelLimitsInfos(String voltageLevelId, double lowLimit, double highLimit, double nominalV) {
+public record VoltageLevelLimitInfo(String voltageLevelId, double lowLimit, double highLimit, double nominalV) {
 }

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/VoltageLevelLimitsInfos.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/VoltageLevelLimitsInfos.java
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openreac.parameters.input;
+
+/**
+ * @author Franck Lecuyer {@literal <franck.lecuyer at rte-france.com>}
+ */
+public record VoltageLevelLimitsInfos(String voltageLevelId, double lowLimit, double highLimit, double nominalV) {
+}

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/VoltageLevelLimitsOverrideInput.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/VoltageLevelLimitsOverrideInput.java
@@ -9,7 +9,6 @@ package com.powsybl.openreac.parameters.input;
 import com.powsybl.ampl.converter.AmplSubset;
 import com.powsybl.ampl.executor.AmplInputFile;
 import com.powsybl.commons.report.ReportNode;
-import com.powsybl.commons.report.TypedValue;
 import com.powsybl.commons.util.StringToIntMapper;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VoltageLevel;
@@ -19,13 +18,12 @@ import org.jgrapht.alg.util.Pair;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+
+import static com.powsybl.openreac.Reports.reportVoltageLevelsWithLimitsOutOfNominalVRange;
 
 /**
  * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
@@ -40,7 +38,6 @@ public class VoltageLevelLimitsOverrideInput implements AmplInputFile {
     private static final double VOLTAGE_LIMIT_LOW_THRESHOLD = 0.85;
     private static final double VOLTAGE_LIMIT_HIGH_THRESHOLD = 1.15;
     private static final double VOLTAGE_LIMIT_TOLERANCE = 5;
-    private static final DecimalFormat LIMIT_VALUE_FORMAT = new DecimalFormat("0.0", DecimalFormatSymbols.getInstance(Locale.ROOT));
 
     public VoltageLevelLimitsOverrideInput(List<VoltageLimitOverride> voltageLimitsOverrides, Network network, ReportNode reportNode) {
         Objects.requireNonNull(voltageLimitsOverrides);
@@ -51,7 +48,7 @@ public class VoltageLevelLimitsOverrideInput implements AmplInputFile {
 
     private void checkLimitsInNominalVoltageRange(Network network, ReportNode reportNode) {
         // check that the limits are in the nominal voltage range [0.85 * nominal_V - 5, 1.15 * nominal_V + 5]
-        Map<String, VoltageLevelLimitsInfos> voltageLevelsWithLimitsOutOfNominalVRange = new HashMap<>();
+        Map<String, VoltageLevelLimitInfo> voltageLevelsWithLimitsOutOfNominalVRange = new HashMap<>();
         for (Map.Entry<String, Pair<Double, Double>> entry : normalizedVoltageLimitsOverride.entrySet()) {
             String voltageLevelId = entry.getKey();
             VoltageLevel voltageLevel = network.getVoltageLevel(voltageLevelId);
@@ -63,26 +60,11 @@ public class VoltageLevelLimitsOverrideInput implements AmplInputFile {
                 lowLimit > VOLTAGE_LIMIT_HIGH_THRESHOLD * nominalV + VOLTAGE_LIMIT_TOLERANCE ||
                 highLimit < VOLTAGE_LIMIT_LOW_THRESHOLD * nominalV - VOLTAGE_LIMIT_TOLERANCE ||
                 highLimit > VOLTAGE_LIMIT_HIGH_THRESHOLD * nominalV + VOLTAGE_LIMIT_TOLERANCE) {
-                voltageLevelsWithLimitsOutOfNominalVRange.put(voltageLevelId, new VoltageLevelLimitsInfos(voltageLevelId, lowLimit, highLimit, nominalV));
+                voltageLevelsWithLimitsOutOfNominalVRange.put(voltageLevelId, new VoltageLevelLimitInfo(voltageLevelId, lowLimit, highLimit, nominalV));
             }
         }
 
-        if (!voltageLevelsWithLimitsOutOfNominalVRange.isEmpty()) {
-            reportNode.newReportNode()
-                .withMessageTemplate("nbVoltageLevelsWithLimitsOutOfNominalVRange", "Acceptable voltage range for ${size} voltage levels seems to be inconsistent with nominal voltage")
-                .withSeverity(TypedValue.WARN_SEVERITY)
-                .withUntypedValue("size", voltageLevelsWithLimitsOutOfNominalVRange.size())
-                .add();
-
-            voltageLevelsWithLimitsOutOfNominalVRange.forEach((voltageLevelId, voltageLevelLimitsInfos) -> reportNode.newReportNode()
-                .withMessageTemplate("voltageLevelWithLimitsOutOfNominalVRange", "Acceptable voltage range for voltage level ${vID} seems to be inconsistent with nominal voltage : low voltage limit = ${lowVoltageLimit} kV, high voltage limit = ${highVoltageLimit} kV, nominal voltage = ${nominalVoltage} kV")
-                .withSeverity(TypedValue.TRACE_SEVERITY)
-                .withUntypedValue("vID", voltageLevelLimitsInfos.voltageLevelId())
-                .withUntypedValue("lowVoltageLimit", LIMIT_VALUE_FORMAT.format(voltageLevelLimitsInfos.lowLimit()))
-                .withUntypedValue("highVoltageLimit", LIMIT_VALUE_FORMAT.format(voltageLevelLimitsInfos.highLimit()))
-                .withUntypedValue("nominalVoltage", voltageLevelLimitsInfos.nominalV())
-                .add());
-        }
+        reportVoltageLevelsWithLimitsOutOfNominalVRange(reportNode, voltageLevelsWithLimitsOutOfNominalVRange);
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No


**What is the current behavior?**
<!-- You can also link to an open issue here -->
After limits overriding, an exception is thrown if a voltage level low limit is greater than the nominal voltage, and also if a voltage level high limit is less than the nominal voltage. And thus, the computation is not done ...

**What is the new behavior (if this is a feature change)?**
We check now that the limits are in a required nominal voltage range : [0.85 * nominal_V - 5, 1.15 * nominal_V + 5]
If it's not the case, we do not throw an exception, we just report and let the computation continue.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

