### PR TITLE
Added checks for numerical consistency of the R/X ratio of network branches (lines + transformers)

### DIFF
--- a/commons/src/main/resources/com/powsybl/optimizer/commons/reports.properties
+++ b/commons/src/main/resources/com/powsybl/optimizer/commons/reports.properties
@@ -15,3 +15,9 @@ optimizer.openreac.voltageLevelWithInconsistentLimits = ${vlId} has one or two i
 optimizer.openreac.voltageLevelWithLimitsOutOfNominalVRange = Acceptable voltage range for voltage level ${vID} seems to be inconsistent with nominal voltage : low voltage limit = ${lowVoltageLimit} kV, high voltage limit = ${highVoltageLimit} kV, nominal voltage = ${nominalVoltage} kV.
 optimizer.openreac.voltageLevelWithLowerLimitMissing = ${vlId} has undefined low voltage limit.
 optimizer.openreac.voltageLevelWithUpperLimitMissing = ${vlId} has undefined high voltage limit.
+optimizer.openreac.nbFrenchBranchesWithHighImpedanceRatio = ${size} French branch(es) have r > 10 * |x|, which is not supported by OpenReac
+optimizer.openreac.frenchBranchWithHighImpedanceRatio = ${branchType} ''${branchId}'': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})
+optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio = ${size} French branch(es) have r > |x| (may cause numerical issues)
+optimizer.openreac.frenchBranchWithAcceptableHighImpedanceRatio = ${branchType} ''${branchId}'': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})
+optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio = ${size} non-French branch(es) have r > |x| (may cause numerical issues)
+optimizer.openreac.nonFrenchBranchWithHighImpedanceRatio = ${branchType} ''${branchId}'': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})

--- a/commons/src/main/resources/com/powsybl/optimizer/commons/reports.properties
+++ b/commons/src/main/resources/com/powsybl/optimizer/commons/reports.properties
@@ -16,8 +16,8 @@ optimizer.openreac.voltageLevelWithLimitsOutOfNominalVRange = Acceptable voltage
 optimizer.openreac.voltageLevelWithLowerLimitMissing = ${vlId} has undefined low voltage limit.
 optimizer.openreac.voltageLevelWithUpperLimitMissing = ${vlId} has undefined high voltage limit.
 optimizer.openreac.nbFrenchBranchesWithHighImpedanceRatio = ${size} French branch(es) have r > 10 * |x|, which is not supported by OpenReac
-optimizer.openreac.frenchBranchWithHighImpedanceRatio = ${branchType} ''${branchId}'': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})
+optimizer.openreac.frenchBranchWithHighImpedanceRatio = '${branchId}': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})
 optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio = ${size} French branch(es) have r > |x| (may cause numerical issues)
-optimizer.openreac.frenchBranchWithAcceptableHighImpedanceRatio = ${branchType} ''${branchId}'': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})
+optimizer.openreac.frenchBranchWithAcceptableHighImpedanceRatio = '${branchId}': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})
 optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio = ${size} non-French branch(es) have r > |x| (may cause numerical issues)
-optimizer.openreac.nonFrenchBranchWithHighImpedanceRatio = ${branchType} ''${branchId}'': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})
+optimizer.openreac.nonFrenchBranchWithHighImpedanceRatio = '${branchId}': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})

--- a/commons/src/main/resources/com/powsybl/optimizer/commons/reports.properties
+++ b/commons/src/main/resources/com/powsybl/optimizer/commons/reports.properties
@@ -21,3 +21,5 @@ optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio = ${size} Fr
 optimizer.openreac.frenchBranchWithAcceptableHighImpedanceRatio = '${branchId}': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})
 optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio = ${size} non-French branch(es) have r > |x| (may cause numerical issues)
 optimizer.openreac.nonFrenchBranchWithHighImpedanceRatio = '${branchId}': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})
+optimizer.openreac.nbBranchesWithLowReactance = ${size} branch(es) with reactance below threshold (ratio check skipped)
+optimizer.openreac.branchWithLowReactance = Branch '${branchId}': x=${x} Ω (threshold=${threshold} Ω) - ratio check skipped due to low reactance

--- a/commons/src/main/resources/com/powsybl/optimizer/commons/reports.properties
+++ b/commons/src/main/resources/com/powsybl/optimizer/commons/reports.properties
@@ -21,5 +21,5 @@ optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio = ${size} Fr
 optimizer.openreac.frenchBranchWithAcceptableHighImpedanceRatio = '${branchId}': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})
 optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio = ${size} non-French branch(es) have r > |x| (may cause numerical issues)
 optimizer.openreac.nonFrenchBranchWithHighImpedanceRatio = '${branchId}': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})
-optimizer.openreac.nbBranchesWithLowReactance = ${size} branch(es) with reactance below threshold (ratio check skipped)
-optimizer.openreac.branchWithLowReactance = Branch '${branchId}': x=${x} Ω (threshold=${threshold} Ω) - ratio check skipped due to low reactance
+optimizer.openreac.nbBranchesWithLowReactance = ${size} branch(es) with reactance below threshold
+optimizer.openreac.branchWithLowReactance = Branch '${branchId}': x=${x} Ω (threshold=${threshold} Ω)

--- a/commons/src/main/resources/com/powsybl/optimizer/commons/reports.properties
+++ b/commons/src/main/resources/com/powsybl/optimizer/commons/reports.properties
@@ -21,5 +21,5 @@ optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio = ${size} Fr
 optimizer.openreac.frenchBranchWithAcceptableHighImpedanceRatio = '${branchId}': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})
 optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio = ${size} non-French branch(es) have r > |x| (may cause numerical issues)
 optimizer.openreac.nonFrenchBranchWithHighImpedanceRatio = '${branchId}': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})
-optimizer.openreac.nbBranchesWithLowReactance = ${size} branch(es) with reactance below threshold
-optimizer.openreac.branchWithLowReactance = Branch '${branchId}': x=${x} Ω (threshold=${threshold} Ω)
+optimizer.openreac.nbBranchesWithLowImpedance = ${size} branch(es) with impedance below threshold
+optimizer.openreac.branchWithLowImpedance = Branch '${branchId}': r=${r} Ω, x=${x} Ω (threshold=${threshold} Ω)

--- a/commons/src/main/resources/com/powsybl/optimizer/commons/reports_fr.properties
+++ b/commons/src/main/resources/com/powsybl/optimizer/commons/reports_fr.properties
@@ -15,3 +15,11 @@ optimizer.openreac.voltageLevelWithInconsistentLimits = ${vlId} a une ou deux li
 optimizer.openreac.voltageLevelWithLimitsOutOfNominalVRange = L'intervalle de tension acceptable pour le poste ${vID} semble incohérent avec la tension nominale : limite basse de tension = ${lowVoltageLimit} kV, limite haute de tension = ${highVoltageLimit} kV, tension nominale = ${nominalVoltage} kV.
 optimizer.openreac.voltageLevelWithLowerLimitMissing = La limite basse de tension du poste ${vlId} est manquante.
 optimizer.openreac.voltageLevelWithUpperLimitMissing = La limite haute de tension du poste ${vlId} est manquante.
+optimizer.openreac.nbFrenchBranchesWithHighImpedanceRatio = ${size} branche(s) sur le territoire français ont r > 10 * |x|, ce qui n'est pas permis par OpenReac.
+optimizer.openreac.frenchBranchWithHighImpedanceRatio = '${branchId}': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})
+optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio = ${size} branche(s) sur le territoire français ont r > |x| (peut causer des problèmes).
+optimizer.openreac.frenchBranchWithAcceptableHighImpedanceRatio = '${branchId}': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})
+optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio = ${size} branche(s) non française(s) ont r > |x| (peut causer des problèmes).
+optimizer.openreac.nonFrenchBranchWithHighImpedanceRatio = '${branchId}': r=${r} Ω, x=${x} Ω (r/|x|=${ratio})
+optimizer.openreac.nbBranchesWithLowImpedance = ${size} branche(s) avec une impédance inférieure au seuil.
+optimizer.openreac.branchWithLowImpedance = Branche '${branchId}': r=${r} Ω, x=${x} Ω (seuil=${threshold} Ω)

--- a/open-reac/src/main/java/com/powsybl/openreac/Reports.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/Reports.java
@@ -34,6 +34,7 @@ public final class Reports {
 
     private static final DecimalFormat VALUE_FORMAT = new DecimalFormat("0.0", DecimalFormatSymbols.getInstance(Locale.ROOT));
     private static final DecimalFormat VALUE_FORMAT_ACCURATE = new DecimalFormat("0.00", DecimalFormatSymbols.getInstance(Locale.ROOT));
+    private static final DecimalFormat VALUE_FORMAT_SCIENTIFIC = new DecimalFormat("0.00E00", DecimalFormatSymbols.getInstance(Locale.ROOT));
 
     private Reports() {
         // Should not be instantiated
@@ -218,6 +219,25 @@ public final class Reports {
                 .withUntypedValue(RESISTANCE, VALUE_FORMAT_ACCURATE.format(r))
                 .withUntypedValue(REACTANCE, VALUE_FORMAT_ACCURATE.format(x))
                 .withUntypedValue(RATIO, VALUE_FORMAT_ACCURATE.format(ratio))
+                .add();
+    }
+
+    public static void reportNbBranchesWithLowReactance(ReportNode reportNode, int size) {
+        reportNode.newReportNode()
+                .withMessageTemplate("optimizer.openreac.nbBranchesWithLowReactance")
+                .withSeverity(TypedValue.WARN_SEVERITY)
+                .withUntypedValue(SIZE, size)
+                .add();
+    }
+
+    public static void reportBranchWithLowReactance(ReportNode reportNode, String branchId,
+                                                    double x, double threshold) {
+        reportNode.newReportNode()
+                .withMessageTemplate("optimizer.openreac.branchWithLowReactance")
+                .withSeverity(TypedValue.DETAIL_SEVERITY)
+                .withUntypedValue(BRANCH_ID, branchId)
+                .withUntypedValue(REACTANCE, VALUE_FORMAT_SCIENTIFIC.format(x))
+                .withUntypedValue("threshold", VALUE_FORMAT_SCIENTIFIC.format(threshold))
                 .add();
     }
 }

--- a/open-reac/src/main/java/com/powsybl/openreac/Reports.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/Reports.java
@@ -222,20 +222,21 @@ public final class Reports {
                 .add();
     }
 
-    public static void reportNbBranchesWithLowReactance(ReportNode reportNode, int size) {
+    public static void reportNbBranchesWithLowImpedance(ReportNode reportNode, int size) {
         reportNode.newReportNode()
-                .withMessageTemplate("optimizer.openreac.nbBranchesWithLowReactance")
+                .withMessageTemplate("optimizer.openreac.nbBranchesWithLowImpedance")
                 .withSeverity(TypedValue.WARN_SEVERITY)
                 .withUntypedValue(SIZE, size)
                 .add();
     }
 
-    public static void reportBranchWithLowReactance(ReportNode reportNode, String branchId,
-                                                    double x, double threshold) {
+    public static void reportBranchWithLowImpedance(ReportNode reportNode, String branchId,
+                                                    double r, double x, double threshold) {
         reportNode.newReportNode()
-                .withMessageTemplate("optimizer.openreac.branchWithLowReactance")
+                .withMessageTemplate("optimizer.openreac.branchWithLowImpedance")
                 .withSeverity(TypedValue.DETAIL_SEVERITY)
                 .withUntypedValue(BRANCH_ID, branchId)
+                .withUntypedValue(RESISTANCE, VALUE_FORMAT_SCIENTIFIC.format(r))
                 .withUntypedValue(REACTANCE, VALUE_FORMAT_SCIENTIFIC.format(x))
                 .withUntypedValue("threshold", VALUE_FORMAT_SCIENTIFIC.format(threshold))
                 .add();

--- a/open-reac/src/main/java/com/powsybl/openreac/Reports.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/Reports.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 /**
  * @author Joris Mancini {@literal <joris.mancini_externe at rte-france.com>}
+ * @author Oscar Lamolet {@literal <lamoletoscar at proton.me>}
  */
 public final class Reports {
 
@@ -151,5 +152,68 @@ public final class Reports {
                 .withUntypedValue("nominalVoltage", voltageLevelLimitInfo.nominalV())
                 .add());
         }
+    }
+
+    public static void reportNbFrenchBranchesWithHighImpedanceRatio(ReportNode reportNode, int size) {
+        reportNode.newReportNode()
+                .withMessageTemplate("optimizer.openreac.nbFrenchBranchesWithHighImpedanceRatio")
+                .withSeverity(TypedValue.ERROR_SEVERITY)
+                .withUntypedValue("size", size)
+                .add();
+    }
+
+    public static void reportFrenchBranchWithHighImpedanceRatio(ReportNode reportNode, String branchId, String branchType,
+                                                                double r, double x, double ratio) {
+        reportNode.newReportNode()
+                .withMessageTemplate("optimizer.openreac.frenchBranchWithHighImpedanceRatio")
+                .withSeverity(TypedValue.DETAIL_SEVERITY)
+                .withUntypedValue("branchId", branchId)
+                .withUntypedValue("branchType", branchType)
+                .withUntypedValue("r", VALUE_FORMAT.format(r))
+                .withUntypedValue("x", VALUE_FORMAT.format(x))
+                .withUntypedValue("ratio", VALUE_FORMAT.format(ratio))
+                .add();
+    }
+
+    public static void reportNbFrenchBranchesWithAcceptableHighImpedanceRatio(ReportNode reportNode, int size) {
+        reportNode.newReportNode()
+                .withMessageTemplate("optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio")
+                .withSeverity(TypedValue.WARN_SEVERITY)
+                .withUntypedValue("size", size)
+                .add();
+    }
+
+    public static void reportFrenchBranchWithAcceptableHighImpedanceRatio(ReportNode reportNode, String branchId, String branchType,
+                                                                          double r, double x, double ratio) {
+        reportNode.newReportNode()
+                .withMessageTemplate("optimizer.openreac.frenchBranchWithAcceptableHighImpedanceRatio")
+                .withSeverity(TypedValue.DETAIL_SEVERITY)
+                .withUntypedValue("branchId", branchId)
+                .withUntypedValue("branchType", branchType)
+                .withUntypedValue("r", VALUE_FORMAT.format(r))
+                .withUntypedValue("x", VALUE_FORMAT.format(x))
+                .withUntypedValue("ratio", VALUE_FORMAT.format(ratio))
+                .add();
+    }
+
+    public static void reportNbNonFrenchBranchesWithHighImpedanceRatio(ReportNode reportNode, int size) {
+        reportNode.newReportNode()
+                .withMessageTemplate("optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio")
+                .withSeverity(TypedValue.WARN_SEVERITY)
+                .withUntypedValue("size", size)
+                .add();
+    }
+
+    public static void reportNonFrenchBranchWithHighImpedanceRatio(ReportNode reportNode, String branchId, String branchType,
+                                                                   double r, double x, double ratio) {
+        reportNode.newReportNode()
+                .withMessageTemplate("optimizer.openreac.nonFrenchBranchWithHighImpedanceRatio")
+                .withSeverity(TypedValue.DETAIL_SEVERITY)
+                .withUntypedValue("branchId", branchId)
+                .withUntypedValue("branchType", branchType)
+                .withUntypedValue("r", VALUE_FORMAT.format(r))
+                .withUntypedValue("x", VALUE_FORMAT.format(x))
+                .withUntypedValue("ratio", VALUE_FORMAT.format(ratio))
+                .add();
     }
 }

--- a/open-reac/src/main/java/com/powsybl/openreac/Reports.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/Reports.java
@@ -28,12 +28,12 @@ public final class Reports {
     private static final String NETWORK_ID = "networkId";
     private static final String SIZE = "size";
     private static final String BRANCH_ID = "branchId";
-    private static final String BRANCH_TYPE = "branchType";
     private static final String RESISTANCE = "r";
     private static final String REACTANCE = "x";
     private static final String RATIO = "ratio";
 
     private static final DecimalFormat VALUE_FORMAT = new DecimalFormat("0.0", DecimalFormatSymbols.getInstance(Locale.ROOT));
+    private static final DecimalFormat VALUE_FORMAT_ACCURATE = new DecimalFormat("0.00", DecimalFormatSymbols.getInstance(Locale.ROOT));
 
     private Reports() {
         // Should not be instantiated
@@ -169,16 +169,15 @@ public final class Reports {
                 .add();
     }
 
-    public static void reportFrenchBranchWithHighImpedanceRatio(ReportNode reportNode, String branchId, String branchType,
+    public static void reportFrenchBranchWithHighImpedanceRatio(ReportNode reportNode, String branchId,
                                                                 double r, double x, double ratio) {
         reportNode.newReportNode()
                 .withMessageTemplate("optimizer.openreac.frenchBranchWithHighImpedanceRatio")
                 .withSeverity(TypedValue.DETAIL_SEVERITY)
                 .withUntypedValue(BRANCH_ID, branchId)
-                .withUntypedValue(BRANCH_TYPE, branchType)
-                .withUntypedValue(RESISTANCE, VALUE_FORMAT.format(r))
-                .withUntypedValue(REACTANCE, VALUE_FORMAT.format(x))
-                .withUntypedValue(RATIO, VALUE_FORMAT.format(ratio))
+                .withUntypedValue(RESISTANCE, VALUE_FORMAT_ACCURATE.format(r))
+                .withUntypedValue(REACTANCE, VALUE_FORMAT_ACCURATE.format(x))
+                .withUntypedValue(RATIO, VALUE_FORMAT_ACCURATE.format(ratio))
                 .add();
     }
 
@@ -190,16 +189,15 @@ public final class Reports {
                 .add();
     }
 
-    public static void reportFrenchBranchWithAcceptableHighImpedanceRatio(ReportNode reportNode, String branchId, String branchType,
+    public static void reportFrenchBranchWithAcceptableHighImpedanceRatio(ReportNode reportNode, String branchId,
                                                                           double r, double x, double ratio) {
         reportNode.newReportNode()
                 .withMessageTemplate("optimizer.openreac.frenchBranchWithAcceptableHighImpedanceRatio")
                 .withSeverity(TypedValue.DETAIL_SEVERITY)
                 .withUntypedValue(BRANCH_ID, branchId)
-                .withUntypedValue(BRANCH_TYPE, branchType)
-                .withUntypedValue(RESISTANCE, VALUE_FORMAT.format(r))
-                .withUntypedValue(REACTANCE, VALUE_FORMAT.format(x))
-                .withUntypedValue(RATIO, VALUE_FORMAT.format(ratio))
+                .withUntypedValue(RESISTANCE, VALUE_FORMAT_ACCURATE.format(r))
+                .withUntypedValue(REACTANCE, VALUE_FORMAT_ACCURATE.format(x))
+                .withUntypedValue(RATIO, VALUE_FORMAT_ACCURATE.format(ratio))
                 .add();
     }
 
@@ -211,16 +209,15 @@ public final class Reports {
                 .add();
     }
 
-    public static void reportNonFrenchBranchWithHighImpedanceRatio(ReportNode reportNode, String branchId, String branchType,
+    public static void reportNonFrenchBranchWithHighImpedanceRatio(ReportNode reportNode, String branchId,
                                                                    double r, double x, double ratio) {
         reportNode.newReportNode()
                 .withMessageTemplate("optimizer.openreac.nonFrenchBranchWithHighImpedanceRatio")
                 .withSeverity(TypedValue.DETAIL_SEVERITY)
                 .withUntypedValue(BRANCH_ID, branchId)
-                .withUntypedValue(BRANCH_TYPE, branchType)
-                .withUntypedValue(RESISTANCE, VALUE_FORMAT.format(r))
-                .withUntypedValue(REACTANCE, VALUE_FORMAT.format(x))
-                .withUntypedValue(RATIO, VALUE_FORMAT.format(ratio))
+                .withUntypedValue(RESISTANCE, VALUE_FORMAT_ACCURATE.format(r))
+                .withUntypedValue(REACTANCE, VALUE_FORMAT_ACCURATE.format(x))
+                .withUntypedValue(RATIO, VALUE_FORMAT_ACCURATE.format(ratio))
                 .add();
     }
 }

--- a/open-reac/src/main/java/com/powsybl/openreac/Reports.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/Reports.java
@@ -26,6 +26,13 @@ import java.util.Map;
 public final class Reports {
 
     private static final String NETWORK_ID = "networkId";
+    private static final String SIZE = "size";
+    private static final String BRANCH_ID = "branchId";
+    private static final String BRANCH_TYPE = "branchType";
+    private static final String RESISTANCE = "r";
+    private static final String REACTANCE = "x";
+    private static final String RATIO = "ratio";
+
     private static final DecimalFormat VALUE_FORMAT = new DecimalFormat("0.0", DecimalFormatSymbols.getInstance(Locale.ROOT));
 
     private Reports() {
@@ -75,7 +82,7 @@ public final class Reports {
         reportNode.newReportNode()
             .withMessageTemplate("optimizer.openreac.constantQGeneratorsSize")
             .withSeverity(TypedValue.INFO_SEVERITY)
-            .withUntypedValue("size", constantQGeneratorsSize)
+            .withUntypedValue(SIZE, constantQGeneratorsSize)
             .add();
     }
 
@@ -101,7 +108,7 @@ public final class Reports {
         reportNode.newReportNode()
                 .withMessageTemplate("optimizer.openreac.nbVoltageLevelsWithInconsistentLimits")
                 .withSeverity(TypedValue.ERROR_SEVERITY)
-                .withUntypedValue("size", voltageLevelsWithInconsistentLimitsSize)
+                .withUntypedValue(SIZE, voltageLevelsWithInconsistentLimitsSize)
                 .add();
     }
 
@@ -109,7 +116,7 @@ public final class Reports {
         reportNode.newReportNode()
                 .withMessageTemplate("optimizer.openreac.nbVoltageLevelsWithMissingLimits")
                 .withSeverity(TypedValue.ERROR_SEVERITY)
-                .withUntypedValue("size", voltageLevelsWithMissingLimitsSize)
+                .withUntypedValue(SIZE, voltageLevelsWithMissingLimitsSize)
                 .add();
     }
 
@@ -117,7 +124,7 @@ public final class Reports {
         reportNode.newReportNode()
                 .withMessageTemplate("optimizer.openreac.variableShuntCompensatorsSize")
                 .withSeverity(TypedValue.INFO_SEVERITY)
-                .withUntypedValue("size", variableShuntCompensatorsSize)
+                .withUntypedValue(SIZE, variableShuntCompensatorsSize)
                 .add();
     }
 
@@ -125,7 +132,7 @@ public final class Reports {
         reportNode.newReportNode()
             .withMessageTemplate("optimizer.openreac.variableTwoWindingsTransformersSize")
             .withSeverity(TypedValue.INFO_SEVERITY)
-            .withUntypedValue("size", variableTwoWindingsTransformersSize)
+            .withUntypedValue(SIZE, variableTwoWindingsTransformersSize)
             .add();
     }
 
@@ -140,7 +147,7 @@ public final class Reports {
             reportLimitsOutOfRange.newReportNode()
                 .withMessageTemplate("optimizer.openreac.nbVoltageLevelsWithLimitsOutOfNominalVRange")
                 .withSeverity(TypedValue.WARN_SEVERITY)
-                .withUntypedValue("size", voltageLevelsWithLimitsOutOfNominalVRange.size())
+                .withUntypedValue(SIZE, voltageLevelsWithLimitsOutOfNominalVRange.size())
                 .add();
 
             voltageLevelsWithLimitsOutOfNominalVRange.forEach((voltageLevelId, voltageLevelLimitInfo) -> reportLimitsOutOfRange.newReportNode()
@@ -158,7 +165,7 @@ public final class Reports {
         reportNode.newReportNode()
                 .withMessageTemplate("optimizer.openreac.nbFrenchBranchesWithHighImpedanceRatio")
                 .withSeverity(TypedValue.ERROR_SEVERITY)
-                .withUntypedValue("size", size)
+                .withUntypedValue(SIZE, size)
                 .add();
     }
 
@@ -167,11 +174,11 @@ public final class Reports {
         reportNode.newReportNode()
                 .withMessageTemplate("optimizer.openreac.frenchBranchWithHighImpedanceRatio")
                 .withSeverity(TypedValue.DETAIL_SEVERITY)
-                .withUntypedValue("branchId", branchId)
-                .withUntypedValue("branchType", branchType)
-                .withUntypedValue("r", VALUE_FORMAT.format(r))
-                .withUntypedValue("x", VALUE_FORMAT.format(x))
-                .withUntypedValue("ratio", VALUE_FORMAT.format(ratio))
+                .withUntypedValue(BRANCH_ID, branchId)
+                .withUntypedValue(BRANCH_TYPE, branchType)
+                .withUntypedValue(RESISTANCE, VALUE_FORMAT.format(r))
+                .withUntypedValue(REACTANCE, VALUE_FORMAT.format(x))
+                .withUntypedValue(RATIO, VALUE_FORMAT.format(ratio))
                 .add();
     }
 
@@ -179,7 +186,7 @@ public final class Reports {
         reportNode.newReportNode()
                 .withMessageTemplate("optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio")
                 .withSeverity(TypedValue.WARN_SEVERITY)
-                .withUntypedValue("size", size)
+                .withUntypedValue(SIZE, size)
                 .add();
     }
 
@@ -188,11 +195,11 @@ public final class Reports {
         reportNode.newReportNode()
                 .withMessageTemplate("optimizer.openreac.frenchBranchWithAcceptableHighImpedanceRatio")
                 .withSeverity(TypedValue.DETAIL_SEVERITY)
-                .withUntypedValue("branchId", branchId)
-                .withUntypedValue("branchType", branchType)
-                .withUntypedValue("r", VALUE_FORMAT.format(r))
-                .withUntypedValue("x", VALUE_FORMAT.format(x))
-                .withUntypedValue("ratio", VALUE_FORMAT.format(ratio))
+                .withUntypedValue(BRANCH_ID, branchId)
+                .withUntypedValue(BRANCH_TYPE, branchType)
+                .withUntypedValue(RESISTANCE, VALUE_FORMAT.format(r))
+                .withUntypedValue(REACTANCE, VALUE_FORMAT.format(x))
+                .withUntypedValue(RATIO, VALUE_FORMAT.format(ratio))
                 .add();
     }
 
@@ -200,7 +207,7 @@ public final class Reports {
         reportNode.newReportNode()
                 .withMessageTemplate("optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio")
                 .withSeverity(TypedValue.WARN_SEVERITY)
-                .withUntypedValue("size", size)
+                .withUntypedValue(SIZE, size)
                 .add();
     }
 
@@ -209,11 +216,11 @@ public final class Reports {
         reportNode.newReportNode()
                 .withMessageTemplate("optimizer.openreac.nonFrenchBranchWithHighImpedanceRatio")
                 .withSeverity(TypedValue.DETAIL_SEVERITY)
-                .withUntypedValue("branchId", branchId)
-                .withUntypedValue("branchType", branchType)
-                .withUntypedValue("r", VALUE_FORMAT.format(r))
-                .withUntypedValue("x", VALUE_FORMAT.format(x))
-                .withUntypedValue("ratio", VALUE_FORMAT.format(ratio))
+                .withUntypedValue(BRANCH_ID, branchId)
+                .withUntypedValue(BRANCH_TYPE, branchType)
+                .withUntypedValue(RESISTANCE, VALUE_FORMAT.format(r))
+                .withUntypedValue(REACTANCE, VALUE_FORMAT.format(x))
+                .withUntypedValue(RATIO, VALUE_FORMAT.format(ratio))
                 .add();
     }
 }

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
@@ -674,7 +674,7 @@ public class OpenReacParameters {
      *  <li>WARNING (does not stop execution)</li>
      * </ul></p>
      * <br/>
-     * <p>Also:</p>
+     * <p>After that:</p>
      * <br/>
      * <p>For French branches (both substations in France):
      * <ul>

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
@@ -7,7 +7,9 @@
 package com.powsybl.openreac.parameters.input;
 
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.Substation;
 import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.openreac.Reports;
 import com.powsybl.openreac.exceptions.InvalidParametersException;
@@ -23,6 +25,7 @@ import java.util.*;
  *
  * @author Nicolas Pierre {@literal <nicolas.pierre at artelys.com>}
  * @author Pierre Arvy {@literal <pierre.arvy at artelys.com>}
+ * @author Oscar Lamolet {@literal <lamoletoscar at proton.me>}
  */
 public class OpenReacParameters {
 
@@ -658,6 +661,165 @@ public class OpenReacParameters {
     }
 
     /**
+     * Check that all branches in the network respect the impedance constraint
+     *
+     * For French branches (both substations in France):
+     *   - Test: r > 10 * |x| -> ERROR (stops execution)
+     *   - Test: r > |x|      -> WARNING (does not stop execution)
+     *
+     * For non-French branches (at least one substation outside France):
+     *   - Test: r > |x|      -> WARNING (does not stop execution)
+     *
+     * @param network the network on which branches are verified
+     * @param reportNode aggregates functional logging
+     * @throws InvalidParametersException if at least one French branch violates the constraint
+     */
+    private void checkBranchImpedanceRatio(Network network, ReportNode reportNode) throws InvalidParametersException {
+        List<BranchImpedanceInfo> violatingFrenchBranches = new ArrayList<>();
+        List<BranchImpedanceInfo> problematicFrenchBranches = new ArrayList<>();
+        List<BranchImpedanceInfo> problematicNonFrenchBranches = new ArrayList<>();
+
+        // Check lines
+        network.getLineStream().forEach(line -> {
+            double r = line.getR();  // in Ohms
+            double x = line.getX();  // in Ohms
+            double vNom1 = line.getTerminal1().getVoltageLevel().getNominalV();
+            double vNom2 = line.getTerminal2().getVoltageLevel().getNominalV();
+
+            // Check if both substations are in France
+            boolean isFrench = isFrenchBranch(
+                line.getTerminal1().getVoltageLevel().getSubstation().orElse(null),
+                line.getTerminal2().getVoltageLevel().getSubstation().orElse(null)
+            );
+
+            double ratio = r / Math.abs(x);
+
+            if (isFrench) {
+                if (ratio > 10) {
+                    violatingFrenchBranches.add(new BranchImpedanceInfo(
+                        line.getId(), "Line", r, x, ratio, vNom1, vNom2));
+                } else if (ratio > 1) {
+                    problematicFrenchBranches.add(new BranchImpedanceInfo(
+                        line.getId(), "Line", r, x, ratio, vNom1, vNom2));
+                }
+            } else {
+                if (ratio > 1) {
+                    problematicNonFrenchBranches.add(new BranchImpedanceInfo(
+                        line.getId(), "Line", r, x, ratio, vNom1, vNom2));
+                }
+            }
+        });
+
+        // Check two windings transformers
+        network.getTwoWindingsTransformerStream().forEach(transformer -> {
+            double r = transformer.getR();  // in Ohms
+            double x = transformer.getX();  // in Ohms
+            double vNom1 = transformer.getTerminal1().getVoltageLevel().getNominalV();
+            double vNom2 = transformer.getTerminal2().getVoltageLevel().getNominalV();
+
+            // Check if both substations are in France
+            boolean isFrench = isFrenchBranch(
+                transformer.getTerminal1().getVoltageLevel().getSubstation().orElse(null),
+                transformer.getTerminal2().getVoltageLevel().getSubstation().orElse(null)
+            );
+
+            double ratio = r / Math.abs(x);
+
+            if (isFrench) {
+                if (ratio > 10) {
+                    violatingFrenchBranches.add(new BranchImpedanceInfo(
+                        transformer.getId(), "Two windings transformer", r, x, ratio, vNom1, vNom2));
+                } else if (ratio > 1) {
+                    problematicFrenchBranches.add(new BranchImpedanceInfo(
+                        transformer.getId(), "Two windings transformer", r, x, ratio, vNom1, vNom2));
+                }
+            } else {
+                if (ratio > 1) {
+                    problematicNonFrenchBranches.add(new BranchImpedanceInfo(
+                        transformer.getId(), "Two windings transformer", r, x, ratio, vNom1, vNom2));
+                }
+            }
+        });
+
+        // Report warnings for French branches
+        if (!problematicFrenchBranches.isEmpty()) {
+            Reports.reportNbFrenchBranchesWithAcceptableHighImpedanceRatio(reportNode, problematicFrenchBranches.size());
+            problematicFrenchBranches.forEach(branch -> {
+                Reports.reportFrenchBranchWithAcceptableHighImpedanceRatio(reportNode, branch.id, branch.type,
+                                                                      branch.r, branch.x, branch.ratio);
+                LOGGER.warn("French branch with high impedance ratio: {} '{}': r={} Ω, x={} Ω (r/|x|={}) [Vnom1={} kV, Vnom2={} kV]",
+                    branch.type, branch.id, branch.r, branch.x, branch.ratio, branch.vNom1, branch.vNom2);
+            });
+        }
+
+        // Report warnings for non-French branches
+        if (!problematicNonFrenchBranches.isEmpty()) {
+            Reports.reportNbNonFrenchBranchesWithHighImpedanceRatio(reportNode, problematicNonFrenchBranches.size());
+            problematicNonFrenchBranches.forEach(branch -> {
+                Reports.reportNonFrenchBranchWithHighImpedanceRatio(reportNode, branch.id, branch.type,
+                                                                      branch.r, branch.x, branch.ratio);
+                LOGGER.warn("Non-French branch with high impedance ratio: {} '{}': r={} Ω, x={} Ω (r/|x|={}) [Vnom1={} kV, Vnom2={} kV]",
+                    branch.type, branch.id, branch.r, branch.x, branch.ratio, branch.vNom1, branch.vNom2);
+            });
+        }
+
+        // Report and throw error for French branches
+        if (!violatingFrenchBranches.isEmpty()) {
+            Reports.reportNbFrenchBranchesWithHighImpedanceRatio(reportNode, violatingFrenchBranches.size());
+            StringBuilder errorMessage = new StringBuilder();
+            errorMessage.append("The following French branches have r > 10 * |x|, which is not supported by OpenReac:\n");
+            violatingFrenchBranches.forEach(branch -> {
+                Reports.reportFrenchBranchWithHighImpedanceRatio(reportNode, branch.id, branch.type,
+                                                                   branch.r, branch.x, branch.ratio);
+                String message = String.format("%s '%s': r=%.6f Ω, x=%.6f Ω (r/|x|=%.2f) [Vnom1=%.1f kV, Vnom2=%.1f kV]",
+                    branch.type, branch.id, branch.r, branch.x, branch.ratio, branch.vNom1, branch.vNom2);
+                errorMessage.append("  - ").append(message).append("\n");
+                LOGGER.error("French branch impedance validation failed: {}", message);
+            });
+            throw new InvalidParametersException(errorMessage.toString());
+        }
+    }
+
+    /**
+     * Internal class to store branch impedance information
+     */
+    private static class BranchImpedanceInfo {
+        final String id;
+        final String type;
+        final double r;
+        final double x;
+        final double ratio;
+        final double vNom1;
+        final double vNom2;
+
+        BranchImpedanceInfo(String id, String type, double r, double x, double ratio, double vNom1, double vNom2) {
+            this.id = id;
+            this.type = type;
+            this.r = r;
+            this.x = x;
+            this.ratio = ratio;
+            this.vNom1 = vNom1;
+            this.vNom2 = vNom2;
+        }
+    }
+
+    /**
+     * Check if a branch is French (both substations in France)
+     *
+     * @param substation1 the first substation
+     * @param substation2 the second substation
+     * @return true if both substations are in France, false otherwise
+     */
+    private boolean isFrenchBranch(Substation substation1, Substation substation2) {
+        if (substation1 == null || substation2 == null) {
+            return false;
+        }
+        Country country1 = substation1.getCountry().orElse(null);
+        Country country2 = substation2.getCountry().orElse(null);
+        return country1 == Country.FR && country2 == Country.FR;
+    }
+
+    /**
      * Do some checks on the parameters given, such as provided IDs must correspond to the given network element
      *
      * @param network     Network on which ID are going to be infered
@@ -687,6 +849,9 @@ public class OpenReacParameters {
                 throw new InvalidParametersException("Bus " + busId + NOT_FOUND_IN_NETWORK);
             }
         }
+
+        // Check branch impedance ratio constraint
+        checkBranchImpedanceRatio(network, reportNode);
 
         // Check integrity of voltage overrides
         boolean integrityVoltageLimitOverrides = checkVoltageLimitOverrides(network, voltageLevelsWithInconsistentLimits);

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
@@ -687,6 +687,7 @@ public class OpenReacParameters {
         List<BranchImpedanceInfo> violatingFrenchBranches = new ArrayList<>();
         List<BranchImpedanceInfo> problematicFrenchBranches = new ArrayList<>();
         List<BranchImpedanceInfo> problematicNonFrenchBranches = new ArrayList<>();
+        List<BranchImpedanceInfo> branchesWithLowReactance = new ArrayList<>();
 
         // Check all branches
         Stream.<Branch<?>>concat(
@@ -697,6 +698,12 @@ public class OpenReacParameters {
             double x = getX(branch);  // in Ohms
             double vNom1 = branch.getTerminal1().getVoltageLevel().getNominalV();
             double vNom2 = branch.getTerminal2().getVoltageLevel().getNominalV();
+
+            // Check if reactance is too low
+            if (Math.abs(x) < lowImpedanceThreshold) {
+                branchesWithLowReactance.add(new BranchImpedanceInfo(branch.getId(), r, x, 0.0, vNom1, vNom2));
+                return;  // Skip ratio check for this branch
+            }
 
             // Check if both substations are in France
             boolean isFrench = isFrenchBranch(
@@ -716,6 +723,16 @@ public class OpenReacParameters {
                 }
             }
         });
+
+        // Report branches with low reactance
+        if (!branchesWithLowReactance.isEmpty()) {
+            Reports.reportNbBranchesWithLowReactance(reportNode, branchesWithLowReactance.size());
+            branchesWithLowReactance.forEach(branch -> {
+                Reports.reportBranchWithLowReactance(reportNode, branch.id, branch.x, lowImpedanceThreshold);
+                LOGGER.warn("Branch with low reactance: '{}': x={} Ω (threshold={} Ω) [Vnom1={} kV, Vnom2={} kV]",
+                    branch.id, branch.x, lowImpedanceThreshold, branch.vNom1, branch.vNom2);
+            });
+        }
 
         // Report warnings for French branches
         if (!problematicFrenchBranches.isEmpty()) {

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
@@ -136,6 +136,12 @@ public class OpenReacParameters {
 
     private double shuntCompensatorActivationAlertThreshold;
 
+    // Redundant strings
+
+    private static final String TRANSFORMERS_KEY = "Two windings transformer";
+
+    private static final String LINES_KEY = "Line";
+
     /**
      * Override some voltage level limits in the network. This will NOT modify the network object.
      * <p>
@@ -694,18 +700,16 @@ public class OpenReacParameters {
 
             double ratio = r / Math.abs(x);
 
-            if (isFrench) {
-                if (ratio > 10) {
+            if (ratio > 1) {
+                if (isFrench && ratio > 10) {
                     violatingFrenchBranches.add(new BranchImpedanceInfo(
-                        line.getId(), "Line", r, x, ratio, vNom1, vNom2));
-                } else if (ratio > 1) {
+                        line.getId(), LINES_KEY, r, x, ratio, vNom1, vNom2));
+                } else if (isFrench) {
                     problematicFrenchBranches.add(new BranchImpedanceInfo(
-                        line.getId(), "Line", r, x, ratio, vNom1, vNom2));
-                }
-            } else {
-                if (ratio > 1) {
+                        line.getId(), LINES_KEY, r, x, ratio, vNom1, vNom2));
+                } else {
                     problematicNonFrenchBranches.add(new BranchImpedanceInfo(
-                        line.getId(), "Line", r, x, ratio, vNom1, vNom2));
+                        line.getId(), LINES_KEY, r, x, ratio, vNom1, vNom2));
                 }
             }
         });
@@ -725,18 +729,16 @@ public class OpenReacParameters {
 
             double ratio = r / Math.abs(x);
 
-            if (isFrench) {
-                if (ratio > 10) {
+            if (ratio > 1) {
+                if (isFrench && ratio > 10) {
                     violatingFrenchBranches.add(new BranchImpedanceInfo(
-                        transformer.getId(), "Two windings transformer", r, x, ratio, vNom1, vNom2));
-                } else if (ratio > 1) {
+                        transformer.getId(), TRANSFORMERS_KEY, r, x, ratio, vNom1, vNom2));
+                } else if (isFrench) {
                     problematicFrenchBranches.add(new BranchImpedanceInfo(
-                        transformer.getId(), "Two windings transformer", r, x, ratio, vNom1, vNom2));
-                }
-            } else {
-                if (ratio > 1) {
+                        transformer.getId(), TRANSFORMERS_KEY, r, x, ratio, vNom1, vNom2));
+                } else {
                     problematicNonFrenchBranches.add(new BranchImpedanceInfo(
-                        transformer.getId(), "Two windings transformer", r, x, ratio, vNom1, vNom2));
+                        transformer.getId(), TRANSFORMERS_KEY, r, x, ratio, vNom1, vNom2));
                 }
             }
         });

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
@@ -668,6 +668,14 @@ public class OpenReacParameters {
     /**
      * <p>Check that all branches in the network respect the impedance constraint.</p>
      * <br/>
+     * <p>For all branches, when <code>|x| < threshold</code>:
+     * <ul>
+     *  <li><code>|x| = threshold</code></li>
+     *  <li>WARNING (does not stop execution)</li>
+     * </ul></p>
+     * <br/>
+     * <p>Also:</p>
+     * <br/>
      * <p>For French branches (both substations in France):
      * <ul>
      *   <li>When <code>r > 10 * |x|</code>: ERROR (stops execution)</li>
@@ -702,7 +710,7 @@ public class OpenReacParameters {
             // Check if reactance is too low
             if (Math.abs(x) < lowImpedanceThreshold) {
                 branchesWithLowReactance.add(new BranchImpedanceInfo(branch.getId(), r, x, 0.0, vNom1, vNom2));
-                return;  // Skip ratio check for this branch
+                x = lowImpedanceThreshold;
             }
 
             // Check if both substations are in France

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
@@ -689,9 +689,9 @@ public class OpenReacParameters {
         List<BranchImpedanceInfo> problematicNonFrenchBranches = new ArrayList<>();
 
         // Check all branches
-        Stream.concat(
-                network.getLineStream().map(l -> (Branch<?>) l),
-                network.getTwoWindingsTransformerStream().map(t -> (Branch<?>) t)
+        Stream.<Branch<?>>concat(
+                network.getLineStream(),
+                network.getTwoWindingsTransformerStream()
         ).forEach(branch -> {
             double r = getR(branch);  // in Ohms
             double x = getX(branch);  // in Ohms

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
@@ -7,9 +7,12 @@
 package com.powsybl.openreac.parameters.input;
 
 import com.powsybl.commons.report.ReportNode;
+import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Line;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.Substation;
+import com.powsybl.iidm.network.TwoWindingsTransformer;
 import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.openreac.Reports;
 import com.powsybl.openreac.exceptions.InvalidParametersException;
@@ -19,6 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.function.ToDoubleFunction;
+import java.util.stream.Stream;
 
 /**
  * This class stores all inputs parameters specific to the OpenReac optimizer.
@@ -135,12 +140,6 @@ public class OpenReacParameters {
     // (to help reporting the shunt compensators with a delta between optimized and discretized reactive value over this threshold in MVar)
 
     private double shuntCompensatorActivationAlertThreshold;
-
-    // Redundant strings
-
-    private static final String TRANSFORMERS_KEY = "Two windings transformer";
-
-    private static final String LINES_KEY = "Line";
 
     /**
      * Override some voltage level limits in the network. This will NOT modify the network object.
@@ -667,14 +666,18 @@ public class OpenReacParameters {
     }
 
     /**
-     * Check that all branches in the network respect the impedance constraint
-     *
-     * For French branches (both substations in France):
-     *   - Test: r > 10 * |x| -> ERROR (stops execution)
-     *   - Test: r > |x|      -> WARNING (does not stop execution)
-     *
-     * For non-French branches (at least one substation outside France):
-     *   - Test: r > |x|      -> WARNING (does not stop execution)
+     * <p>Check that all branches in the network respect the impedance constraint.</p>
+     * <br/>
+     * <p>For French branches (both substations in France):
+     * <ul>
+     *   <li>When <code>r > 10 * |x|</code>: ERROR (stops execution)</li>
+     *   <li>When <code>r > |x|</code>: WARNING (does not stop execution)</li>
+     * </ul></p>
+     * <br/>
+     * <p>For non-French branches (at least one substation outside France):
+     * <ul>
+     *   <li>When <code>r > |x|</code>: WARNING (does not stop execution)</li>
+     * </ul></p>
      *
      * @param network the network on which branches are verified
      * @param reportNode aggregates functional logging
@@ -685,60 +688,31 @@ public class OpenReacParameters {
         List<BranchImpedanceInfo> problematicFrenchBranches = new ArrayList<>();
         List<BranchImpedanceInfo> problematicNonFrenchBranches = new ArrayList<>();
 
-        // Check lines
-        network.getLineStream().forEach(line -> {
-            double r = line.getR();  // in Ohms
-            double x = line.getX();  // in Ohms
-            double vNom1 = line.getTerminal1().getVoltageLevel().getNominalV();
-            double vNom2 = line.getTerminal2().getVoltageLevel().getNominalV();
+        // Check all branches
+        Stream.concat(
+                network.getLineStream().map(l -> (Branch<?>) l),
+                network.getTwoWindingsTransformerStream().map(t -> (Branch<?>) t)
+        ).forEach(branch -> {
+            double r = getR(branch);  // in Ohms
+            double x = getX(branch);  // in Ohms
+            double vNom1 = branch.getTerminal1().getVoltageLevel().getNominalV();
+            double vNom2 = branch.getTerminal2().getVoltageLevel().getNominalV();
 
             // Check if both substations are in France
             boolean isFrench = isFrenchBranch(
-                line.getTerminal1().getVoltageLevel().getSubstation().orElse(null),
-                line.getTerminal2().getVoltageLevel().getSubstation().orElse(null)
+                    branch.getTerminal1().getVoltageLevel().getSubstation().orElse(null),
+                    branch.getTerminal2().getVoltageLevel().getSubstation().orElse(null)
             );
 
             double ratio = r / Math.abs(x);
 
             if (ratio > 1) {
                 if (isFrench && ratio > 10) {
-                    violatingFrenchBranches.add(new BranchImpedanceInfo(
-                        line.getId(), LINES_KEY, r, x, ratio, vNom1, vNom2));
+                    violatingFrenchBranches.add(new BranchImpedanceInfo(branch.getId(), r, x, ratio, vNom1, vNom2));
                 } else if (isFrench) {
-                    problematicFrenchBranches.add(new BranchImpedanceInfo(
-                        line.getId(), LINES_KEY, r, x, ratio, vNom1, vNom2));
+                    problematicFrenchBranches.add(new BranchImpedanceInfo(branch.getId(), r, x, ratio, vNom1, vNom2));
                 } else {
-                    problematicNonFrenchBranches.add(new BranchImpedanceInfo(
-                        line.getId(), LINES_KEY, r, x, ratio, vNom1, vNom2));
-                }
-            }
-        });
-
-        // Check two windings transformers
-        network.getTwoWindingsTransformerStream().forEach(transformer -> {
-            double r = transformer.getR();  // in Ohms
-            double x = transformer.getX();  // in Ohms
-            double vNom1 = transformer.getTerminal1().getVoltageLevel().getNominalV();
-            double vNom2 = transformer.getTerminal2().getVoltageLevel().getNominalV();
-
-            // Check if both substations are in France
-            boolean isFrench = isFrenchBranch(
-                transformer.getTerminal1().getVoltageLevel().getSubstation().orElse(null),
-                transformer.getTerminal2().getVoltageLevel().getSubstation().orElse(null)
-            );
-
-            double ratio = r / Math.abs(x);
-
-            if (ratio > 1) {
-                if (isFrench && ratio > 10) {
-                    violatingFrenchBranches.add(new BranchImpedanceInfo(
-                        transformer.getId(), TRANSFORMERS_KEY, r, x, ratio, vNom1, vNom2));
-                } else if (isFrench) {
-                    problematicFrenchBranches.add(new BranchImpedanceInfo(
-                        transformer.getId(), TRANSFORMERS_KEY, r, x, ratio, vNom1, vNom2));
-                } else {
-                    problematicNonFrenchBranches.add(new BranchImpedanceInfo(
-                        transformer.getId(), TRANSFORMERS_KEY, r, x, ratio, vNom1, vNom2));
+                    problematicNonFrenchBranches.add(new BranchImpedanceInfo(branch.getId(), r, x, ratio, vNom1, vNom2));
                 }
             }
         });
@@ -747,10 +721,10 @@ public class OpenReacParameters {
         if (!problematicFrenchBranches.isEmpty()) {
             Reports.reportNbFrenchBranchesWithAcceptableHighImpedanceRatio(reportNode, problematicFrenchBranches.size());
             problematicFrenchBranches.forEach(branch -> {
-                Reports.reportFrenchBranchWithAcceptableHighImpedanceRatio(reportNode, branch.id, branch.type,
-                                                                      branch.r, branch.x, branch.ratio);
-                LOGGER.warn("French branch with high impedance ratio: {} '{}': r={} Ω, x={} Ω (r/|x|={}) [Vnom1={} kV, Vnom2={} kV]",
-                    branch.type, branch.id, branch.r, branch.x, branch.ratio, branch.vNom1, branch.vNom2);
+                Reports.reportFrenchBranchWithAcceptableHighImpedanceRatio(reportNode, branch.id,
+                                                                           branch.r, branch.x, branch.ratio);
+                LOGGER.warn("French branch with high impedance ratio: '{}': r={} Ω, x={} Ω (r/|x|={}) [Vnom1={} kV, Vnom2={} kV]",
+                    branch.id, branch.r, branch.x, branch.ratio, branch.vNom1, branch.vNom2);
             });
         }
 
@@ -758,10 +732,10 @@ public class OpenReacParameters {
         if (!problematicNonFrenchBranches.isEmpty()) {
             Reports.reportNbNonFrenchBranchesWithHighImpedanceRatio(reportNode, problematicNonFrenchBranches.size());
             problematicNonFrenchBranches.forEach(branch -> {
-                Reports.reportNonFrenchBranchWithHighImpedanceRatio(reportNode, branch.id, branch.type,
-                                                                      branch.r, branch.x, branch.ratio);
-                LOGGER.warn("Non-French branch with high impedance ratio: {} '{}': r={} Ω, x={} Ω (r/|x|={}) [Vnom1={} kV, Vnom2={} kV]",
-                    branch.type, branch.id, branch.r, branch.x, branch.ratio, branch.vNom1, branch.vNom2);
+                Reports.reportNonFrenchBranchWithHighImpedanceRatio(reportNode, branch.id,
+                                                                    branch.r, branch.x, branch.ratio);
+                LOGGER.warn("Non-French branch with high impedance ratio: '{}': r={} Ω, x={} Ω (r/|x|={}) [Vnom1={} kV, Vnom2={} kV]",
+                    branch.id, branch.r, branch.x, branch.ratio, branch.vNom1, branch.vNom2);
             });
         }
 
@@ -771,10 +745,10 @@ public class OpenReacParameters {
             StringBuilder errorMessage = new StringBuilder();
             errorMessage.append("The following French branches have r > 10 * |x|, which is not supported by OpenReac:\n");
             violatingFrenchBranches.forEach(branch -> {
-                Reports.reportFrenchBranchWithHighImpedanceRatio(reportNode, branch.id, branch.type,
-                                                                   branch.r, branch.x, branch.ratio);
-                String message = String.format("%s '%s': r=%.6f Ω, x=%.6f Ω (r/|x|=%.2f) [Vnom1=%.1f kV, Vnom2=%.1f kV]",
-                    branch.type, branch.id, branch.r, branch.x, branch.ratio, branch.vNom1, branch.vNom2);
+                Reports.reportFrenchBranchWithHighImpedanceRatio(reportNode, branch.id,
+                                                                 branch.r, branch.x, branch.ratio);
+                String message = String.format("'%s': r=%.6f Ω, x=%.6f Ω (r/|x|=%.2f) [Vnom1=%.1f kV, Vnom2=%.1f kV]",
+                    branch.id, branch.r, branch.x, branch.ratio, branch.vNom1, branch.vNom2);
                 errorMessage.append("  - ").append(message).append("\n");
                 LOGGER.error("French branch impedance validation failed: {}", message);
             });
@@ -782,27 +756,29 @@ public class OpenReacParameters {
         }
     }
 
-    /**
-     * Internal class to store branch impedance information
-     */
-    private static class BranchImpedanceInfo {
-        final String id;
-        final String type;
-        final double r;
-        final double x;
-        final double ratio;
-        final double vNom1;
-        final double vNom2;
+    private double getCharactistic(Branch<?> branch,
+                                   ToDoubleFunction<Line> lineCharacteristic,
+                                   ToDoubleFunction<TwoWindingsTransformer> transfoCharacteristic) {
+        return switch (branch) {
+            case Line l -> lineCharacteristic.applyAsDouble(l);
+            case TwoWindingsTransformer t -> transfoCharacteristic.applyAsDouble(t);
+            default -> throw new IllegalStateException("Unexpected value: " + branch);
+        };
+    }
 
-        BranchImpedanceInfo(String id, String type, double r, double x, double ratio, double vNom1, double vNom2) {
-            this.id = id;
-            this.type = type;
-            this.r = r;
-            this.x = x;
-            this.ratio = ratio;
-            this.vNom1 = vNom1;
-            this.vNom2 = vNom2;
-        }
+    private double getR(Branch<?> branch) {
+        return getCharactistic(branch, Line::getR, TwoWindingsTransformer::getR);
+    }
+
+    private double getX(Branch<?> branch) {
+        return getCharactistic(branch, Line::getX, TwoWindingsTransformer::getX);
+    }
+
+    /**
+     * Record to store branch information for impedance ratio validation and reporting
+     * Used to collect and report branches with high r/|x| ratios during the validation
+     */
+    private record BranchImpedanceInfo(String id, double r, double x, double ratio, double vNom1, double vNom2) {
     }
 
     /**

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
@@ -668,23 +668,24 @@ public class OpenReacParameters {
     /**
      * <p>Check that all branches in the network respect the impedance constraint.</p>
      * <br/>
-     * <p>For all branches, when <code>|x| < threshold</code>:
+     * <p>For all branches:
      * <ul>
-     *  <li><code>|x| = threshold</code></li>
-     *  <li>WARNING (does not stop execution)</li>
-     * </ul></p>
-     * <br/>
-     * <p>After that:</p>
-     * <br/>
-     * <p>For French branches (both substations in France):
-     * <ul>
-     *   <li>When <code>r > 10 * |x|</code>: ERROR (stops execution)</li>
-     *   <li>When <code>r > |x|</code>: WARNING (does not stop execution)</li>
-     * </ul></p>
-     * <br/>
-     * <p>For non-French branches (at least one substation outside France):
-     * <ul>
-     *   <li>When <code>r > |x|</code>: WARNING (does not stop execution)</li>
+     *   <li>When <code>|x| < threshold</code>:</li>
+     *   <ul>
+     *     <li><code>x = threshold</code></li>
+     *     <li>WARNING (does not stop execution)</li>
+     *   </ul>
+     *   <br/>
+     *   <li>When the branch is French (both substations in France):</li>
+     *   <ul>
+     *     <li>When <code>r > 10 * |x|</code>: ERROR (stops execution)</li>
+     *     <li>When <code>r > |x|</code>: WARNING (does not stop execution)</li>
+     *   </ul>
+     *   <br/>
+     *   <li>When the branch is non-French (at least one substation outside France):</li>
+     *   <ul>
+     *     <li>When <code>r > |x|</code>: WARNING (does not stop execution)</li>
+     *   </ul>
      * </ul></p>
      *
      * @param network the network on which branches are verified

--- a/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
+++ b/open-reac/src/main/java/com/powsybl/openreac/parameters/input/OpenReacParameters.java
@@ -670,7 +670,7 @@ public class OpenReacParameters {
      * <br/>
      * <p>For all branches:
      * <ul>
-     *   <li>When <code>|x| < threshold</code>:</li>
+     *   <li>When <code>r² + x² <= threshold²</code>:</li>
      *   <ul>
      *     <li><code>x = threshold</code></li>
      *     <li>WARNING (does not stop execution)</li>
@@ -696,7 +696,7 @@ public class OpenReacParameters {
         List<BranchImpedanceInfo> violatingFrenchBranches = new ArrayList<>();
         List<BranchImpedanceInfo> problematicFrenchBranches = new ArrayList<>();
         List<BranchImpedanceInfo> problematicNonFrenchBranches = new ArrayList<>();
-        List<BranchImpedanceInfo> branchesWithLowReactance = new ArrayList<>();
+        List<LowImpedanceBranchInfo> branchesWithLowImpedances = new ArrayList<>();
 
         // Check all branches
         Stream.<Branch<?>>concat(
@@ -708,10 +708,13 @@ public class OpenReacParameters {
             double vNom1 = branch.getTerminal1().getVoltageLevel().getNominalV();
             double vNom2 = branch.getTerminal2().getVoltageLevel().getNominalV();
 
-            // Check if reactance is too low
-            if (Math.abs(x) < lowImpedanceThreshold) {
-                branchesWithLowReactance.add(new BranchImpedanceInfo(branch.getId(), r, x, 0.0, vNom1, vNom2));
-                x = lowImpedanceThreshold;
+            // Conversion of the threshold into Ohms
+            double lowImpedanceThresholdOhms = calculateImpedanceThresholdOhms(vNom1);
+
+            // Check if impedance is too low
+            if (r * r + x * x <= lowImpedanceThresholdOhms * lowImpedanceThresholdOhms) {
+                branchesWithLowImpedances.add(new LowImpedanceBranchInfo(branch.getId(), r, x, vNom1, vNom2, lowImpedanceThresholdOhms));
+                x = lowImpedanceThresholdOhms;
             }
 
             // Check if both substations are in France
@@ -733,13 +736,13 @@ public class OpenReacParameters {
             }
         });
 
-        // Report branches with low reactance
-        if (!branchesWithLowReactance.isEmpty()) {
-            Reports.reportNbBranchesWithLowReactance(reportNode, branchesWithLowReactance.size());
-            branchesWithLowReactance.forEach(branch -> {
-                Reports.reportBranchWithLowReactance(reportNode, branch.id, branch.x, lowImpedanceThreshold);
-                LOGGER.warn("Branch with low reactance: '{}': x={} Ω (threshold={} Ω) [Vnom1={} kV, Vnom2={} kV]",
-                    branch.id, branch.x, lowImpedanceThreshold, branch.vNom1, branch.vNom2);
+        // Report branches with low impedance
+        if (!branchesWithLowImpedances.isEmpty()) {
+            Reports.reportNbBranchesWithLowImpedance(reportNode, branchesWithLowImpedances.size());
+            branchesWithLowImpedances.forEach(branch -> {
+                Reports.reportBranchWithLowImpedance(reportNode, branch.id, branch.r, branch.x, branch.thresholdOhms);
+                LOGGER.warn("Branch with low impedance: '{}': r={} Ω, x={} Ω (threshold={} Ω) [Vnom1={} kV, Vnom2={} kV]",
+                    branch.id, branch.r, branch.x, branch.thresholdOhms, branch.vNom1, branch.vNom2);
             });
         }
 
@@ -801,10 +804,29 @@ public class OpenReacParameters {
     }
 
     /**
+     * Calculate impedance threshold in Ohms for a given nominal voltage
+     *
+     * @param nominalVoltageKv Nominal voltage in kV
+     * @return Impedance threshold in Ohms
+     */
+    private double calculateImpedanceThresholdOhms(double nominalVoltageKv) {
+        double sBase = 100.0;  // MVA (standard base power)
+        double zBase = (nominalVoltageKv * nominalVoltageKv) / sBase;
+        return lowImpedanceThreshold * zBase;
+    }
+
+    /**
      * Record to store branch information for impedance ratio validation and reporting
      * Used to collect and report branches with high r/|x| ratios during the validation
      */
     private record BranchImpedanceInfo(String id, double r, double x, double ratio, double vNom1, double vNom2) {
+    }
+
+    /**
+     * Record to store branch information for impedance value validation and reporting
+     * Used to collect and report branches with low impedance
+     */
+    private record LowImpedanceBranchInfo(String id, double r, double x, double vNom1, double vNom2, double thresholdOhms) {
     }
 
     /**

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
@@ -60,6 +60,7 @@ class BranchImpedanceValidationTest {
 
         // Should have warning in ReportNode
         assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.frenchBranchWithAcceptableHighImpedanceRatio"));
     }
 
     /**
@@ -77,6 +78,7 @@ class BranchImpedanceValidationTest {
 
         // Should have no warnings about impedance ratio
         assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.frenchBranchWithAcceptableHighImpedanceRatio"));
     }
 
     /**
@@ -94,6 +96,7 @@ class BranchImpedanceValidationTest {
 
         // Should have warning in ReportNode
         assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio"));
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nonFrenchBranchWithHighImpedanceRatio"));
     }
 
     /**
@@ -111,6 +114,7 @@ class BranchImpedanceValidationTest {
 
         // Should have no warnings about non-French branches
         assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio"));
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nonFrenchBranchWithHighImpedanceRatio"));
     }
 
     /**
@@ -163,6 +167,7 @@ class BranchImpedanceValidationTest {
 
         // Should have warning (1 < 5 <= 10)
         assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.frenchBranchWithAcceptableHighImpedanceRatio"));
     }
 
     // ========== Tests for low impedance detection (sqrt(r² + x²) <= threshold) ==========
@@ -189,33 +194,16 @@ class BranchImpedanceValidationTest {
 
         // Should NOT have ratio warnings (ratio < 1)
         assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
-        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithHighImpedanceRatio"));
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.frenchBranchWithAcceptableHighImpedanceRatio"));
     }
 
     /**
-     * Test branch with very small impedance in all directions
+     * Test branch with impedance exactly at threshold boundary with maximum possible r
+     * r=0.16, x=0 -> sqrt(0.0256 + 0.0) = 0.16 Ω (exactly at threshold)
      */
     @Test
-    void testBranchWithVerySmallImpedance() {
-        // r=0.05, x=0.05 -> sqrt(0.0025 + 0.0025) = 0.071 Ω << 0.16 Ω
-        Network network = createNetworkWithFrenchLine(0.05, 0.05);
-
-        OpenReacParameters params = new OpenReacParameters();
-        ReportNode reportNode = createReportNode();
-
-        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
-
-        // Should have warning about low impedance
-        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbBranchesWithLowImpedance"));
-    }
-
-    /**
-     * Test branch with impedance exactly at threshold boundary
-     * r=0.16, x=0 -> sqrt(0.0256) = 0.16 Ω (exactly at threshold)
-     */
-    @Test
-    void testBranchWithImpedanceAtThreshold() {
-        // At the boundary: should trigger low impedance warning (condition is <=, but 0.16 == 0.16)
+    void testBranchWithImpedanceAtThresholdAndMaxR() {
+        // After replacement x = 0.16, ratio = 0.16/0.16 = 1.0 (boundary)
         Network network = createNetworkWithFrenchLine(0.16, 0.0);
 
         OpenReacParameters params = new OpenReacParameters();
@@ -225,10 +213,36 @@ class BranchImpedanceValidationTest {
 
         // Should have low impedance warning (0.16 <= 0.16 is true)
         assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbBranchesWithLowImpedance"));
+
+        // Should NOT have ratio warning (1 <= 1 after threshold replacement)
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio"));
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nonFrenchBranchWithHighImpedanceRatio"));
     }
 
     /**
-     * Test branch with impedance just above threshold
+     * Test branch with impedance exactly at threshold boundary with maximum possible x
+     * r=0, x=0.16 -> sqrt(0.0 + 0.0256) = 0.16 Ω (exactly at threshold)
+     */
+    @Test
+    void testBranchWithImpedanceAtThresholdAndMaxX() {
+        // After replacement x = 0.16, ratio = 0/0.16 = 0.0
+        Network network = createNetworkWithFrenchLine(0.16, 0.0);
+
+        OpenReacParameters params = new OpenReacParameters();
+        ReportNode reportNode = createReportNode();
+
+        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
+
+        // Should have low impedance warning (0.16 <= 0.16 is true)
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbBranchesWithLowImpedance"));
+
+        // Should NOT have ratio warning (0 <= 1 after threshold replacement)
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio"));
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nonFrenchBranchWithHighImpedanceRatio"));
+    }
+
+    /**
+     * Test branch with impedance above threshold
      * r=2.0, x=0.2 -> sqrt(4 + 0.04) = 2.01 Ω > 0.16 Ω -> normal check applies
      */
     @Test
@@ -247,6 +261,7 @@ class BranchImpedanceValidationTest {
 
         // Should have warning about acceptable high ratio (1 < 10 <= 10)
         assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.frenchBranchWithAcceptableHighImpedanceRatio"));
     }
 
     /**
@@ -267,50 +282,7 @@ class BranchImpedanceValidationTest {
 
         // Should NOT have ratio warning (ratio < 1 after threshold replacement)
         assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio"));
-    }
-
-    /**
-     * Test that low impedance with maximum possible r still results in ratio <= 1
-     * This validates the mathematical constraint: if sqrt(r²+x²) <= threshold,
-     * then after x replacement, ratio = r/threshold <= 1
-     */
-    @Test
-    void testLowImpedanceMaxRatioConstraint() {
-        // Maximum r for low impedance: r ≈ 0.16, x ≈ 0
-        // sqrt(0.0256 + 0) = 0.16 Ω, at threshold
-        // After replacement x = 0.16, ratio = 0.16/0.16 = 1.0 (boundary)
-        Network network = createNetworkWithFrenchLine(0.159, 0.01);
-
-        OpenReacParameters params = new OpenReacParameters();
-        ReportNode reportNode = createReportNode();
-
-        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
-
-        // Should have low impedance warning
-        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbBranchesWithLowImpedance"));
-
-        // Should NOT have ratio warning (ratio ≈ 0.99 < 1)
-        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
-    }
-
-    /**
-     * Test branch with low impedance due to very small x (but r is larger)
-     * r=0.15, x=0.05 -> sqrt(0.0225 + 0.0025) = 0.158 Ω < 0.16 Ω
-     */
-    @Test
-    void testLowImpedanceWithAsymmetricValues() {
-        Network network = createNetworkWithFrenchLine(0.15, 0.05);
-
-        OpenReacParameters params = new OpenReacParameters();
-        ReportNode reportNode = createReportNode();
-
-        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
-
-        // Should have low impedance warning
-        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbBranchesWithLowImpedance"));
-
-        // After x -> 0.16, ratio = 0.15/0.16 = 0.938 < 1, no ratio warning
-        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nonFrenchBranchWithHighImpedanceRatio"));
     }
 
     // ========== Helper methods to create test networks ==========

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
@@ -165,6 +165,27 @@ class BranchImpedanceValidationTest {
         assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
     }
 
+    /**
+     * Test that branches with very low reactance generate a warning and skip ratio check
+     */
+    @Test
+    void testBranchWithVeryLowReactanceGeneratesWarning() {
+        Network network = createNetworkWithFrenchLine(10.0, 1e-6); // x = 1e-6 < threshold
+
+        OpenReacParameters params = new OpenReacParameters();
+        ReportNode reportNode = createReportNode();
+
+        // Should not throw (even though r/|x| would be very high)
+        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
+
+        // Should have warning about low reactance
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbBranchesWithLowReactance"));
+
+        // Should NOT have ratio warnings (ratio check was skipped)
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithHighImpedanceRatio"));
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
+    }
+
     // ========== Helper methods to create test networks ==========
 
     /**

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
@@ -36,10 +36,9 @@ class BranchImpedanceValidationTest {
         Network network = createNetworkWithFrenchLine(12.0, 1.0); // ratio = 12 > 10
 
         OpenReacParameters params = new OpenReacParameters();
-        ReportNode reportNode = createReportNode();
 
         InvalidParametersException exception = assertThrows(InvalidParametersException.class,
-                () -> params.checkIntegrity(network, reportNode.NO_OP));
+                () -> params.checkIntegrity(network, ReportNode.NO_OP));
 
         assertTrue(exception.getMessage().contains("French branches have r > 10 * |x|"));
         assertTrue(exception.getMessage().contains("'LINE_FR'"));
@@ -121,10 +120,9 @@ class BranchImpedanceValidationTest {
         Network network = createNetworkWithFrenchTransformer(15.0, 1.0); // ratio = 15 > 10
 
         OpenReacParameters params = new OpenReacParameters();
-        ReportNode reportNode = createReportNode();
 
         InvalidParametersException exception = assertThrows(InvalidParametersException.class,
-                () -> params.checkIntegrity(network, reportNode));
+                () -> params.checkIntegrity(network, ReportNode.NO_OP));
 
         assertTrue(exception.getMessage().contains("French branches have r > 10 * |x|"));
         assertTrue(exception.getMessage().contains("'TRANSFO_FR'"));
@@ -138,10 +136,9 @@ class BranchImpedanceValidationTest {
         Network network = createMixedNetwork();
 
         OpenReacParameters params = new OpenReacParameters();
-        ReportNode reportNode = createReportNode();
 
         InvalidParametersException exception = assertThrows(InvalidParametersException.class,
-                () -> params.checkIntegrity(network, reportNode));
+                () -> params.checkIntegrity(network, ReportNode.NO_OP));
 
         // Should mention French branch error
         assertTrue(exception.getMessage().contains("French branches have r > 10 * |x|"));

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
@@ -11,6 +11,7 @@ import com.powsybl.iidm.network.*;
 import com.powsybl.openreac.exceptions.InvalidParametersException;
 import org.junit.jupiter.api.Test;
 
+import static com.powsybl.openreac.parameters.input.ReportTestHelper.hasReportWithKey;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -23,7 +24,7 @@ class BranchImpedanceValidationTest {
      */
     private ReportNode createReportNode() {
         return ReportNode.newRootReportNode()
-                .withMessageTemplate("branchImpedanceValidationTest", "Branch Impedance Validation Test")
+                .withMessageTemplate("branchImpedanceValidationTest")
                 .build();
     }
 
@@ -38,10 +39,10 @@ class BranchImpedanceValidationTest {
         ReportNode reportNode = createReportNode();
 
         InvalidParametersException exception = assertThrows(InvalidParametersException.class,
-                () -> params.checkIntegrity(network, reportNode));
+                () -> params.checkIntegrity(network, reportNode.NO_OP));
 
         assertTrue(exception.getMessage().contains("French branches have r > 10 * |x|"));
-        assertTrue(exception.getMessage().contains("Line 'LINE_FR'"));
+        assertTrue(exception.getMessage().contains("'LINE_FR'"));
     }
 
     /**
@@ -58,8 +59,7 @@ class BranchImpedanceValidationTest {
         assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
 
         // Should have warning in ReportNode
-        boolean hasWarning = hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio");
-        assertTrue(hasWarning, "Expected warning report for French branch with moderate impedance ratio");
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
     }
 
     /**
@@ -76,8 +76,7 @@ class BranchImpedanceValidationTest {
         assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
 
         // Should have no warnings about impedance
-        boolean hasWarning = hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio");
-        assertFalse(hasWarning, "Should not have warning for French branch with low impedance ratio");
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
     }
 
     /**
@@ -94,8 +93,7 @@ class BranchImpedanceValidationTest {
         assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
 
         // Should have warning in ReportNode
-        boolean hasWarning = hasReportWithKey(reportNode, "optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio");
-        assertTrue(hasWarning, "Expected warning report for non-French branch with high impedance ratio");
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio"));
     }
 
     /**
@@ -112,8 +110,7 @@ class BranchImpedanceValidationTest {
         assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
 
         // Should have no warnings about non-French branches
-        boolean hasWarning = hasReportWithKey(reportNode, "optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio");
-        assertFalse(hasWarning, "Should not have warning for non-French branch with low impedance ratio");
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio"));
     }
 
     /**
@@ -130,7 +127,7 @@ class BranchImpedanceValidationTest {
                 () -> params.checkIntegrity(network, reportNode));
 
         assertTrue(exception.getMessage().contains("French branches have r > 10 * |x|"));
-        assertTrue(exception.getMessage().contains("Two windings transformer"));
+        assertTrue(exception.getMessage().contains("'TRANSFO_FR'"));
     }
 
     /**
@@ -167,8 +164,7 @@ class BranchImpedanceValidationTest {
         assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
 
         // Should have warning (1 < 5 <= 10)
-        boolean hasWarning = hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio");
-        assertTrue(hasWarning);
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
     }
 
     // ========== Helper methods to create test networks ==========
@@ -421,20 +417,5 @@ class BranchImpedanceValidationTest {
                 .add();
 
         return network;
-    }
-
-    /**
-     * Helper method to check if a ReportNode tree contains a report with a specific message key
-     */
-    private boolean hasReportWithKey(ReportNode node, String messageKey) {
-        if (messageKey.equals(node.getMessageKey())) {
-            return true;
-        }
-        for (ReportNode child : node.getChildren()) {
-            if (hasReportWithKey(child, messageKey)) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
@@ -215,7 +215,7 @@ class BranchImpedanceValidationTest {
      */
     @Test
     void testBranchWithImpedanceAtThreshold() {
-        // At the boundary: should NOT trigger low impedance warning (condition is <=, but 0.16 == 0.16)
+        // At the boundary: should trigger low impedance warning (condition is <=, but 0.16 == 0.16)
         Network network = createNetworkWithFrenchLine(0.16, 0.0);
 
         OpenReacParameters params = new OpenReacParameters();

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
@@ -75,7 +75,7 @@ class BranchImpedanceValidationTest {
         // Should not throw
         assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
 
-        // Should have no warnings about impedance
+        // Should have no warnings about impedance ratio
         assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
     }
 
@@ -165,67 +165,152 @@ class BranchImpedanceValidationTest {
         assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
     }
 
-    /**
-     * Test that branches with very low reactance generate a warning and use threshold for ratio check
-     */
-    @Test
-    void testBranchWithVeryLowReactanceGeneratesWarningAndUsesThreshold() {
-        // x = 1e-5 < threshold (1e-4), so x will be replaced by 1e-4
-        // ratio = 10.0 / 1e-4 = 100,000 >> 10, so this should throw
-        Network network = createNetworkWithFrenchLine(10.0, 1e-5);
-
-        OpenReacParameters params = new OpenReacParameters();
-
-        // Should throw because ratio with threshold is still very high (100,000 > 10)
-        InvalidParametersException exception = assertThrows(InvalidParametersException.class,
-                () -> params.checkIntegrity(network, ReportNode.NO_OP));
-
-        assertTrue(exception.getMessage().contains("French branches have r > 10 * |x|"));
-    }
+    // ========== Tests for low impedance detection (sqrt(r² + x²) <= threshold) ==========
 
     /**
-     * Test that branches with low reactance that result in acceptable ratio after threshold replacement
+     * Test that branches with low impedance (small r and x) generate a warning
+     * For 400 kV: zBase = 1600 Ω, threshold = 1e-4 × 1600 = 0.16 Ω
+     * With low impedance, ratio will always be <= 1 after threshold replacement
      */
     @Test
-    void testBranchWithLowReactanceButAcceptableRatioAfterThreshold() {
-        // x = 1e-5 < threshold (1e-4), so x will be replaced by 1e-4
-        // ratio = 5e-4 / 1e-4 = 5, which is acceptable (1 < 5 <= 10)
-        Network network = createNetworkWithFrenchLine(5e-4, 1e-5);
+    void testBranchWithLowImpedanceGeneratesWarning() {
+        // r=0.1, x=0.1 -> sqrt(0.01 + 0.01) = 0.141 Ω < 0.16 Ω -> low impedance
+        // After replacement x = 0.16 Ω, ratio = 0.1 / 0.16 = 0.625 < 1 -> passes ratio check
+        Network network = createNetworkWithFrenchLine(0.1, 0.1);
 
         OpenReacParameters params = new OpenReacParameters();
         ReportNode reportNode = createReportNode();
 
-        // Should not throw (ratio with threshold is 5, which is acceptable)
+        // Should not throw (ratio after threshold is < 1)
         assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
 
-        // Should have warning about low reactance
-        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbBranchesWithLowReactance"));
-
-        // Should also have warning about acceptable high ratio (1 < 5 <= 10)
-        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
-    }
-
-    /**
-     * Test that branches with low reactance and low resistance pass all checks with only low reactance warning
-     */
-    @Test
-    void testBranchWithLowReactanceAndLowResistance() {
-        // x = 1e-5 < threshold (1e-4), so x will be replaced by 1e-4
-        // ratio = 5e-5 / 1e-4 = 0.5 < 1, which passes
-        Network network = createNetworkWithFrenchLine(5e-5, 1e-5);
-
-        OpenReacParameters params = new OpenReacParameters();
-        ReportNode reportNode = createReportNode();
-
-        // Should not throw (ratio with threshold is 0.5 < 1)
-        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
-
-        // Should have warning about low reactance
-        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbBranchesWithLowReactance"));
+        // Should have warning about low impedance
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbBranchesWithLowImpedance"));
 
         // Should NOT have ratio warnings (ratio < 1)
         assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
         assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithHighImpedanceRatio"));
+    }
+
+    /**
+     * Test branch with very small impedance in all directions
+     */
+    @Test
+    void testBranchWithVerySmallImpedance() {
+        // r=0.05, x=0.05 -> sqrt(0.0025 + 0.0025) = 0.071 Ω << 0.16 Ω
+        Network network = createNetworkWithFrenchLine(0.05, 0.05);
+
+        OpenReacParameters params = new OpenReacParameters();
+        ReportNode reportNode = createReportNode();
+
+        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
+
+        // Should have warning about low impedance
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbBranchesWithLowImpedance"));
+    }
+
+    /**
+     * Test branch with impedance exactly at threshold boundary
+     * r=0.16, x=0 -> sqrt(0.0256) = 0.16 Ω (exactly at threshold)
+     */
+    @Test
+    void testBranchWithImpedanceAtThreshold() {
+        // At the boundary: should NOT trigger low impedance warning (condition is <=, but 0.16 == 0.16)
+        Network network = createNetworkWithFrenchLine(0.16, 0.0);
+
+        OpenReacParameters params = new OpenReacParameters();
+        ReportNode reportNode = createReportNode();
+
+        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
+
+        // Should have low impedance warning (0.16 <= 0.16 is true)
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbBranchesWithLowImpedance"));
+    }
+
+    /**
+     * Test branch with impedance just above threshold
+     * r=2.0, x=0.2 -> sqrt(4 + 0.04) = 2.01 Ω > 0.16 Ω -> normal check applies
+     */
+    @Test
+    void testBranchJustAboveImpedanceThresholdWithHighRatio() {
+        // Above threshold: ratio = 2.0 / 0.2 = 10 (exactly at French warning boundary)
+        Network network = createNetworkWithFrenchLine(2.0, 0.2);
+
+        OpenReacParameters params = new OpenReacParameters();
+        ReportNode reportNode = createReportNode();
+
+        // Should not throw (ratio = 10, condition for error is ratio > 10)
+        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
+
+        // Should NOT have low impedance warning
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbBranchesWithLowImpedance"));
+
+        // Should have warning about acceptable high ratio (1 < 10 <= 10)
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
+    }
+
+    /**
+     * Test non-French branch with low impedance
+     */
+    @Test
+    void testNonFrenchBranchWithLowImpedance() {
+        // International line with low impedance
+        Network network = createNetworkWithInternationalLine(0.1, 0.1);
+
+        OpenReacParameters params = new OpenReacParameters();
+        ReportNode reportNode = createReportNode();
+
+        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
+
+        // Should have low impedance warning (applies to all branches)
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbBranchesWithLowImpedance"));
+
+        // Should NOT have ratio warning (ratio < 1 after threshold replacement)
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio"));
+    }
+
+    /**
+     * Test that low impedance with maximum possible r still results in ratio <= 1
+     * This validates the mathematical constraint: if sqrt(r²+x²) <= threshold,
+     * then after x replacement, ratio = r/threshold <= 1
+     */
+    @Test
+    void testLowImpedanceMaxRatioConstraint() {
+        // Maximum r for low impedance: r ≈ 0.16, x ≈ 0
+        // sqrt(0.0256 + 0) = 0.16 Ω, at threshold
+        // After replacement x = 0.16, ratio = 0.16/0.16 = 1.0 (boundary)
+        Network network = createNetworkWithFrenchLine(0.159, 0.01);
+
+        OpenReacParameters params = new OpenReacParameters();
+        ReportNode reportNode = createReportNode();
+
+        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
+
+        // Should have low impedance warning
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbBranchesWithLowImpedance"));
+
+        // Should NOT have ratio warning (ratio ≈ 0.99 < 1)
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
+    }
+
+    /**
+     * Test branch with low impedance due to very small x (but r is larger)
+     * r=0.15, x=0.05 -> sqrt(0.0225 + 0.0025) = 0.158 Ω < 0.16 Ω
+     */
+    @Test
+    void testLowImpedanceWithAsymmetricValues() {
+        Network network = createNetworkWithFrenchLine(0.15, 0.05);
+
+        OpenReacParameters params = new OpenReacParameters();
+        ReportNode reportNode = createReportNode();
+
+        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
+
+        // Should have low impedance warning
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbBranchesWithLowImpedance"));
+
+        // After x -> 0.16, ratio = 0.15/0.16 = 0.938 < 1, no ratio warning
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
     }
 
     // ========== Helper methods to create test networks ==========

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
@@ -166,24 +166,66 @@ class BranchImpedanceValidationTest {
     }
 
     /**
-     * Test that branches with very low reactance generate a warning and skip ratio check
+     * Test that branches with very low reactance generate a warning and use threshold for ratio check
      */
     @Test
-    void testBranchWithVeryLowReactanceGeneratesWarning() {
-        Network network = createNetworkWithFrenchLine(10.0, 1e-6); // x = 1e-6 < threshold
+    void testBranchWithVeryLowReactanceGeneratesWarningAndUsesThreshold() {
+        // x = 1e-5 < threshold (1e-4), so x will be replaced by 1e-4
+        // ratio = 10.0 / 1e-4 = 100,000 >> 10, so this should throw
+        Network network = createNetworkWithFrenchLine(10.0, 1e-5);
+
+        OpenReacParameters params = new OpenReacParameters();
+
+        // Should throw because ratio with threshold is still very high (100,000 > 10)
+        InvalidParametersException exception = assertThrows(InvalidParametersException.class,
+                () -> params.checkIntegrity(network, ReportNode.NO_OP));
+
+        assertTrue(exception.getMessage().contains("French branches have r > 10 * |x|"));
+    }
+
+    /**
+     * Test that branches with low reactance that result in acceptable ratio after threshold replacement
+     */
+    @Test
+    void testBranchWithLowReactanceButAcceptableRatioAfterThreshold() {
+        // x = 1e-5 < threshold (1e-4), so x will be replaced by 1e-4
+        // ratio = 5e-4 / 1e-4 = 5, which is acceptable (1 < 5 <= 10)
+        Network network = createNetworkWithFrenchLine(5e-4, 1e-5);
 
         OpenReacParameters params = new OpenReacParameters();
         ReportNode reportNode = createReportNode();
 
-        // Should not throw (even though r/|x| would be very high)
+        // Should not throw (ratio with threshold is 5, which is acceptable)
         assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
 
         // Should have warning about low reactance
         assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbBranchesWithLowReactance"));
 
-        // Should NOT have ratio warnings (ratio check was skipped)
-        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithHighImpedanceRatio"));
+        // Should also have warning about acceptable high ratio (1 < 5 <= 10)
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
+    }
+
+    /**
+     * Test that branches with low reactance and low resistance pass all checks with only low reactance warning
+     */
+    @Test
+    void testBranchWithLowReactanceAndLowResistance() {
+        // x = 1e-5 < threshold (1e-4), so x will be replaced by 1e-4
+        // ratio = 5e-5 / 1e-4 = 0.5 < 1, which passes
+        Network network = createNetworkWithFrenchLine(5e-5, 1e-5);
+
+        OpenReacParameters params = new OpenReacParameters();
+        ReportNode reportNode = createReportNode();
+
+        // Should not throw (ratio with threshold is 0.5 < 1)
+        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
+
+        // Should have warning about low reactance
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbBranchesWithLowReactance"));
+
+        // Should NOT have ratio warnings (ratio < 1)
         assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio"));
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithHighImpedanceRatio"));
     }
 
     // ========== Helper methods to create test networks ==========

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
@@ -1,0 +1,440 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openreac.parameters.input;
+
+import com.powsybl.commons.report.ReportNode;
+import com.powsybl.iidm.network.*;
+import com.powsybl.openreac.exceptions.InvalidParametersException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Oscar Lamolet {@literal <lamoletoscar at proton.me>}
+ */
+class BranchImpedanceValidationTest {
+
+    /**
+     * Create a ReportNode for testing
+     */
+    private ReportNode createReportNode() {
+        return ReportNode.newRootReportNode()
+                .withMessageTemplate("branchImpedanceValidationTest", "Branch Impedance Validation Test")
+                .build();
+    }
+
+    /**
+     * Test that French branches with r > 10*|x| throw an error
+     */
+    @Test
+    void testFrenchBranchWithVeryHighImpedanceRatioThrowsError() {
+        Network network = createNetworkWithFrenchLine(12.0, 1.0); // ratio = 12 > 10
+
+        OpenReacParameters params = new OpenReacParameters();
+        ReportNode reportNode = createReportNode();
+
+        InvalidParametersException exception = assertThrows(InvalidParametersException.class,
+                () -> params.checkIntegrity(network, reportNode));
+
+        assertTrue(exception.getMessage().contains("French branches have r > 10 * |x|"));
+        assertTrue(exception.getMessage().contains("Line 'LINE_FR'"));
+    }
+
+    /**
+     * Test that French branches with 1 < r/|x| <= 10 generate a warning but don't throw
+     */
+    @Test
+    void testFrenchBranchWithModerateImpedanceRatioGeneratesWarning() {
+        Network network = createNetworkWithFrenchLine(5.0, 1.0); // ratio = 5, acceptable
+
+        OpenReacParameters params = new OpenReacParameters();
+        ReportNode reportNode = createReportNode();
+
+        // Should not throw
+        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
+
+        // Should have warning in ReportNode
+        boolean hasWarning = hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio");
+        assertTrue(hasWarning, "Expected warning report for French branch with moderate impedance ratio");
+    }
+
+    /**
+     * Test that French branches with r/|x| <= 1 pass validation without warning
+     */
+    @Test
+    void testFrenchBranchWithLowImpedanceRatioPasses() {
+        Network network = createNetworkWithFrenchLine(0.5, 1.0); // ratio = 0.5 < 1
+
+        OpenReacParameters params = new OpenReacParameters();
+        ReportNode reportNode = createReportNode();
+
+        // Should not throw
+        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
+
+        // Should have no warnings about impedance
+        boolean hasWarning = hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio");
+        assertFalse(hasWarning, "Should not have warning for French branch with low impedance ratio");
+    }
+
+    /**
+     * Test that non-French branches with r > |x| generate a warning but don't throw
+     */
+    @Test
+    void testNonFrenchBranchWithHighImpedanceRatioGeneratesWarning() {
+        Network network = createNetworkWithInternationalLine(3.0, 2.0); // ratio = 1.5 > 1
+
+        OpenReacParameters params = new OpenReacParameters();
+        ReportNode reportNode = createReportNode();
+
+        // Should not throw
+        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
+
+        // Should have warning in ReportNode
+        boolean hasWarning = hasReportWithKey(reportNode, "optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio");
+        assertTrue(hasWarning, "Expected warning report for non-French branch with high impedance ratio");
+    }
+
+    /**
+     * Test that non-French branches with r <= |x| pass validation without warning
+     */
+    @Test
+    void testNonFrenchBranchWithLowImpedanceRatioPasses() {
+        Network network = createNetworkWithInternationalLine(0.5, 1.0); // ratio = 0.5 < 1
+
+        OpenReacParameters params = new OpenReacParameters();
+        ReportNode reportNode = createReportNode();
+
+        // Should not throw
+        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
+
+        // Should have no warnings about non-French branches
+        boolean hasWarning = hasReportWithKey(reportNode, "optimizer.openreac.nbNonFrenchBranchesWithHighImpedanceRatio");
+        assertFalse(hasWarning, "Should not have warning for non-French branch with low impedance ratio");
+    }
+
+    /**
+     * Test transformer (two windings) with high impedance ratio
+     */
+    @Test
+    void testFrenchTransformerWithVeryHighImpedanceRatioThrowsError() {
+        Network network = createNetworkWithFrenchTransformer(15.0, 1.0); // ratio = 15 > 10
+
+        OpenReacParameters params = new OpenReacParameters();
+        ReportNode reportNode = createReportNode();
+
+        InvalidParametersException exception = assertThrows(InvalidParametersException.class,
+                () -> params.checkIntegrity(network, reportNode));
+
+        assertTrue(exception.getMessage().contains("French branches have r > 10 * |x|"));
+        assertTrue(exception.getMessage().contains("Two windings transformer"));
+    }
+
+    /**
+     * Test mixed network with multiple violations
+     */
+    @Test
+    void testMixedNetworkWithMultipleViolations() {
+        Network network = createMixedNetwork();
+
+        OpenReacParameters params = new OpenReacParameters();
+        ReportNode reportNode = createReportNode();
+
+        InvalidParametersException exception = assertThrows(InvalidParametersException.class,
+                () -> params.checkIntegrity(network, reportNode));
+
+        // Should mention French branch error
+        assertTrue(exception.getMessage().contains("French branches have r > 10 * |x|"));
+
+        // Should have counted both French and non-French problematic branches
+        // (we can't easily check warnings in the exception case, but they should be logged)
+    }
+
+    /**
+     * Test with negative reactance (edge case)
+     */
+    @Test
+    void testBranchWithNegativeReactance() {
+        Network network = createNetworkWithFrenchLine(5.0, -1.0); // ratio = 5 / |-1| = 5
+
+        OpenReacParameters params = new OpenReacParameters();
+        ReportNode reportNode = createReportNode();
+
+        // Should not throw (ratio = 5, which is acceptable)
+        assertDoesNotThrow(() -> params.checkIntegrity(network, reportNode));
+
+        // Should have warning (1 < 5 <= 10)
+        boolean hasWarning = hasReportWithKey(reportNode, "optimizer.openreac.nbFrenchBranchesWithAcceptableHighImpedanceRatio");
+        assertTrue(hasWarning);
+    }
+
+    // ========== Helper methods to create test networks ==========
+
+    /**
+     * Create a network with a French line (both substations in France)
+     */
+    private Network createNetworkWithFrenchLine(double r, double x) {
+        Network network = Network.create("test", "test");
+
+        Substation s1 = network.newSubstation()
+                .setId("S1")
+                .setCountry(Country.FR)
+                .add();
+
+        Substation s2 = network.newSubstation()
+                .setId("S2")
+                .setCountry(Country.FR)
+                .add();
+
+        VoltageLevel vl1 = s1.newVoltageLevel()
+                .setId("VL1")
+                .setNominalV(400.0)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setLowVoltageLimit(380.0)
+                .setHighVoltageLimit(420.0)
+                .add();
+
+        VoltageLevel vl2 = s2.newVoltageLevel()
+                .setId("VL2")
+                .setNominalV(400.0)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setLowVoltageLimit(380.0)
+                .setHighVoltageLimit(420.0)
+                .add();
+
+        vl1.getBusBreakerView().newBus().setId("B1").add();
+        vl2.getBusBreakerView().newBus().setId("B2").add();
+
+        network.newLine()
+                .setId("LINE_FR")
+                .setVoltageLevel1("VL1")
+                .setBus1("B1")
+                .setVoltageLevel2("VL2")
+                .setBus2("B2")
+                .setR(r)
+                .setX(x)
+                .setG1(0.0)
+                .setB1(0.0)
+                .setG2(0.0)
+                .setB2(0.0)
+                .add();
+
+        return network;
+    }
+
+    /**
+     * Create a network with an international line (France - Germany)
+     */
+    private Network createNetworkWithInternationalLine(double r, double x) {
+        Network network = Network.create("test", "test");
+
+        Substation s1 = network.newSubstation()
+                .setId("S1_FR")
+                .setCountry(Country.FR)
+                .add();
+
+        Substation s2 = network.newSubstation()
+                .setId("S2_DE")
+                .setCountry(Country.DE)
+                .add();
+
+        VoltageLevel vl1 = s1.newVoltageLevel()
+                .setId("VL1")
+                .setNominalV(400.0)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setLowVoltageLimit(380.0)
+                .setHighVoltageLimit(420.0)
+                .add();
+
+        VoltageLevel vl2 = s2.newVoltageLevel()
+                .setId("VL2")
+                .setNominalV(400.0)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setLowVoltageLimit(380.0)
+                .setHighVoltageLimit(420.0)
+                .add();
+
+        vl1.getBusBreakerView().newBus().setId("B1").add();
+        vl2.getBusBreakerView().newBus().setId("B2").add();
+
+        network.newLine()
+                .setId("LINE_INTL")
+                .setVoltageLevel1("VL1")
+                .setBus1("B1")
+                .setVoltageLevel2("VL2")
+                .setBus2("B2")
+                .setR(r)
+                .setX(x)
+                .setG1(0.0)
+                .setB1(0.0)
+                .setG2(0.0)
+                .setB2(0.0)
+                .add();
+
+        return network;
+    }
+
+    /**
+     * Create a network with a French transformer
+     */
+    private Network createNetworkWithFrenchTransformer(double r, double x) {
+        Network network = Network.create("test", "test");
+
+        Substation s = network.newSubstation()
+                .setId("S1")
+                .setCountry(Country.FR)
+                .add();
+
+        VoltageLevel vl1 = s.newVoltageLevel()
+                .setId("VL1")
+                .setNominalV(400.0)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setLowVoltageLimit(380.0)
+                .setHighVoltageLimit(420.0)
+                .add();
+
+        VoltageLevel vl2 = s.newVoltageLevel()
+                .setId("VL2")
+                .setNominalV(225.0)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setLowVoltageLimit(220.0)
+                .setHighVoltageLimit(245.0)
+                .add();
+
+        vl1.getBusBreakerView().newBus().setId("B1").add();
+        vl2.getBusBreakerView().newBus().setId("B2").add();
+
+        s.newTwoWindingsTransformer()
+                .setId("TRANSFO_FR")
+                .setVoltageLevel1("VL1")
+                .setBus1("B1")
+                .setVoltageLevel2("VL2")
+                .setBus2("B2")
+                .setR(r)
+                .setX(x)
+                .setG(0.0)
+                .setB(0.0)
+                .setRatedU1(400.0)
+                .setRatedU2(225.0)
+                .add();
+
+        return network;
+    }
+
+    /**
+     * Create a mixed network with multiple branches of different types
+     */
+    private Network createMixedNetwork() {
+        Network network = Network.create("test", "test");
+
+        // French substations
+        Substation sFr1 = network.newSubstation()
+                .setId("S_FR1")
+                .setCountry(Country.FR)
+                .add();
+
+        Substation sFr2 = network.newSubstation()
+                .setId("S_FR2")
+                .setCountry(Country.FR)
+                .add();
+
+        // German substation
+        Substation sDe = network.newSubstation()
+                .setId("S_DE")
+                .setCountry(Country.DE)
+                .add();
+
+        VoltageLevel vlFr1 = sFr1.newVoltageLevel()
+                .setId("VL_FR1")
+                .setNominalV(400.0)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setLowVoltageLimit(380.0)
+                .setHighVoltageLimit(420.0)
+                .add();
+
+        VoltageLevel vlFr2 = sFr2.newVoltageLevel()
+                .setId("VL_FR2")
+                .setNominalV(400.0)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setLowVoltageLimit(380.0)
+                .setHighVoltageLimit(420.0)
+                .add();
+
+        VoltageLevel vlDe = sDe.newVoltageLevel()
+                .setId("VL_DE")
+                .setNominalV(400.0)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setLowVoltageLimit(380.0)
+                .setHighVoltageLimit(420.0)
+                .add();
+
+        vlFr1.getBusBreakerView().newBus().setId("B_FR1").add();
+        vlFr2.getBusBreakerView().newBus().setId("B_FR2").add();
+        vlDe.getBusBreakerView().newBus().setId("B_DE").add();
+
+        // French line with very high ratio (will throw error)
+        network.newLine()
+                .setId("LINE_FR_BAD")
+                .setVoltageLevel1("VL_FR1")
+                .setBus1("B_FR1")
+                .setVoltageLevel2("VL_FR2")
+                .setBus2("B_FR2")
+                .setR(12.0)  // ratio = 12 > 10 -> ERROR
+                .setX(1.0)
+                .setG1(0.0)
+                .setB1(0.0)
+                .setG2(0.0)
+                .setB2(0.0)
+                .add();
+
+        // French line with moderate ratio (will generate warning)
+        network.newLine()
+                .setId("LINE_FR_WARN")
+                .setVoltageLevel1("VL_FR1")
+                .setBus1("B_FR1")
+                .setVoltageLevel2("VL_FR2")
+                .setBus2("B_FR2")
+                .setR(3.0)  // ratio = 3, 1 < 3 <= 10 -> WARNING
+                .setX(1.0)
+                .setG1(0.0)
+                .setB1(0.0)
+                .setG2(0.0)
+                .setB2(0.0)
+                .add();
+
+        // International line with high ratio (will generate warning)
+        network.newLine()
+                .setId("LINE_INTL_WARN")
+                .setVoltageLevel1("VL_FR1")
+                .setBus1("B_FR1")
+                .setVoltageLevel2("VL_DE")
+                .setBus2("B_DE")
+                .setR(2.0)  // ratio = 2 > 1 -> WARNING
+                .setX(1.0)
+                .setG1(0.0)
+                .setB1(0.0)
+                .setG2(0.0)
+                .setB2(0.0)
+                .add();
+
+        return network;
+    }
+
+    /**
+     * Helper method to check if a ReportNode tree contains a report with a specific message key
+     */
+    private boolean hasReportWithKey(ReportNode node, String messageKey) {
+        if (messageKey.equals(node.getMessageKey())) {
+            return true;
+        }
+        for (ReportNode child : node.getChildren()) {
+            if (hasReportWithKey(child, messageKey)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 package com.powsybl.openreac.parameters.input;
 

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/input/BranchImpedanceValidationTest.java
@@ -226,7 +226,7 @@ class BranchImpedanceValidationTest {
     @Test
     void testBranchWithImpedanceAtThresholdAndMaxX() {
         // After replacement x = 0.16, ratio = 0/0.16 = 0.0
-        Network network = createNetworkWithFrenchLine(0.16, 0.0);
+        Network network = createNetworkWithFrenchLine(0.0, 0.16);
 
         OpenReacParameters params = new OpenReacParameters();
         ReportNode reportNode = createReportNode();

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/input/ReportTestHelper.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/input/ReportTestHelper.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.openreac.parameters.input;
+
+import com.powsybl.commons.report.ReportNode;
+
+/**
+ * Helper utilities for testing ReportNode
+ *
+ * @author Oscar Lamolet {@literal <lamoletoscar at proton.me>}
+ */
+public final class ReportTestHelper {
+
+    private ReportTestHelper() {
+        // Utility class
+    }
+
+    /**
+     * Check if a ReportNode tree contains a report with a specific message key
+     *
+     * @param reportNode the root report node to search in
+     * @param messageKey the message key to search for
+     * @return true if the message key is found in the tree, false otherwise
+     */
+    public static boolean hasReportWithKey(ReportNode reportNode, String messageKey) {
+        if (reportNode.getMessageKey() != null && reportNode.getMessageKey().equals(messageKey)) {
+            return true;
+        }
+        for (ReportNode child : reportNode.getChildren()) {
+            if (hasReportWithKey(child, messageKey)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/input/ReportTestHelper.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/input/ReportTestHelper.java
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 package com.powsybl.openreac.parameters.input;
 

--- a/open-reac/src/test/java/com/powsybl/openreac/parameters/input/VoltageLevelLimitsOverrideInputTest.java
+++ b/open-reac/src/test/java/com/powsybl/openreac/parameters/input/VoltageLevelLimitsOverrideInputTest.java
@@ -23,9 +23,9 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
+import static com.powsybl.openreac.parameters.input.ReportTestHelper.hasReportWithKey;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -217,18 +217,6 @@ class VoltageLevelLimitsOverrideInputTest {
         assertDoesNotThrow(() -> new VoltageLevelLimitsOverrideInput(voltageLimitsOverride2, network, ReportNode.NO_OP));
     }
 
-    private static boolean checkReportWithKey(String key, ReportNode reportNode) {
-        if (reportNode.getMessageKey() != null && reportNode.getMessageKey().equals(key)) {
-            return true;
-        }
-        boolean found = false;
-        Iterator<ReportNode> reportersIterator = reportNode.getChildren().iterator();
-        while (!found && reportersIterator.hasNext()) {
-            found = checkReportWithKey(key, reportersIterator.next());
-        }
-        return found;
-    }
-
     @Test
     void testVoltageOverrideWithLowLimitOutOfNominalVoltageRange() {
         Network network = IeeeCdfNetworkFactory.create57();
@@ -245,14 +233,14 @@ class VoltageLevelLimitsOverrideInputTest {
         // if after override, low limit is in the nominal voltage range, no specific report has been created
         ReportNode reportNode = ReportNode.newRootReportNode().withAllResourceBundlesFromClasspath().withMessageTemplate("optimizer.openreac.openReac").build();
         new VoltageLevelLimitsOverrideInput(voltageLimitsOverride, network, reportNode);
-        assertFalse(checkReportWithKey("optimizer.openreac.nbVoltageLevelsWithLimitsOutOfNominalVRange", reportNode));
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbVoltageLevelsWithLimitsOutOfNominalVRange"));
 
         // if after override, low limit is out of nominal voltage range, a specific report has been created
         reportNode = ReportNode.newRootReportNode().withAllResourceBundlesFromClasspath().withMessageTemplate("optimizer.openreac.openReac").build();
         voltageLimitsOverride.clear();
         voltageLimitsOverride.add(new VoltageLimitOverride(vl.getId(), VoltageLimitOverride.VoltageLimitType.LOW_VOLTAGE_LIMIT, false, 317.));
         new VoltageLevelLimitsOverrideInput(voltageLimitsOverride, network, reportNode);
-        assertTrue(checkReportWithKey("optimizer.openreac.nbVoltageLevelsWithLimitsOutOfNominalVRange", reportNode));
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbVoltageLevelsWithLimitsOutOfNominalVRange"));
     }
 
     @Test
@@ -271,14 +259,14 @@ class VoltageLevelLimitsOverrideInputTest {
         // if after override, high limit is in the nominal voltage range, no specific report has been created
         ReportNode reportNode = ReportNode.newRootReportNode().withAllResourceBundlesFromClasspath().withMessageTemplate("optimizer.openreac.openReac").build();
         new VoltageLevelLimitsOverrideInput(voltageLimitsOverride, network, reportNode);
-        assertFalse(checkReportWithKey("optimizer.openreac.nbVoltageLevelsWithLimitsOutOfNominalVRange", reportNode));
+        assertFalse(hasReportWithKey(reportNode, "optimizer.openreac.nbVoltageLevelsWithLimitsOutOfNominalVRange"));
 
         // if after override, high limit is out of nominal voltage range, a specific report has been created
         reportNode = ReportNode.newRootReportNode().withAllResourceBundlesFromClasspath().withMessageTemplate("optimizer.openreac.openReac").build();
         voltageLimitsOverride.clear();
         voltageLimitsOverride.add(new VoltageLimitOverride(vl.getId(), VoltageLimitOverride.VoltageLimitType.HIGH_VOLTAGE_LIMIT, false, 445.));
         new VoltageLevelLimitsOverrideInput(voltageLimitsOverride, network, reportNode);
-        assertTrue(checkReportWithKey("optimizer.openreac.nbVoltageLevelsWithLimitsOutOfNominalVRange", reportNode));
+        assertTrue(hasReportWithKey(reportNode, "optimizer.openreac.nbVoltageLevelsWithLimitsOutOfNominalVRange"));
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)



**What kind of change does this PR introduce?**

A new data consistency check in the Java part of the tool.



**What is the current behavior?**

There is no verification of the ratio between resistance and reactance in the branches. However, we have found that detecting this type of inconsistency in the data can facilitate debugging in certain instances if that is where the problem lies.



**What is the new behavior (if this is a feature change)?**

The new checks consist of the following: we will iterate over all branches (lines + transformers), then:

If the magnitude of the branch impedance ($\sqrt{r^2 + x^2}$) is smaller or equal than the lower impedance threshold (default: 1e-4 pu converts to ohms for each), a warning is issued, and the value of x is then replaced with this threshold.

Then,

If the branch is French, (the two substations in France):

| Condition | Severity | Action |
|-----------|----------|--------|
| **r > 10 × \|x\|** | ❌ **ERROR** | InvalidParametersException raised after detecting and resending all problematic branches, so after the loop on the branches is completed |
| **r > \|x\|** | ⚠️ **WARNING** | Message logged, continuing execution |

If the branch is not French,  (at least one substation outside France):

| Condition | Severity | Action |
|-----------|----------|--------|
| **r > \|x\|** | ⚠️ **WARNING** | Message logged, continuing execution |



**Does this PR introduce a breaking change or deprecate an API?**

- [ ] Yes
- [x] No
