### PR TITLE
Convert reports_fr from latin1 to utf8

### DIFF
--- a/commons/src/main/resources/com/powsybl/optimizer/commons/reports_fr.properties
+++ b/commons/src/main/resources/com/powsybl/optimizer/commons/reports_fr.properties
@@ -1,17 +1,17 @@
-optimizer.openreac.constantQGeneratorsSize = La consigne de puissance réactive est considérée fixe pour ${size} générateurs.
-optimizer.openreac.nbVoltageLevelsWithInconsistentLimits = La limite haute et/ou basse en tension est/sont incohérente(s) pour ${size} poste(s).
-optimizer.openreac.nbVoltageLevelsWithLimitsOutOfNominalVRange = L'intervalle de tension acceptable semble incohérent avec la tension nominale pour ${size} poste(s).
-optimizer.openreac.nbVoltageLevelsWithMissingLimits = ${size} poste(s) ont une limite basse et/ou haute en tension indéfinie(s).
-optimizer.openreac.openReac = Open Reac sur le réseau '${networkId}' avec la fonction objectif ${objective}.
-optimizer.openreac.openReacParameterIntegrity = Vérification de l'intégrité des paramètres Open reac sur le réseau '${networkId}'.
-optimizer.openreac.shuntCompensatorDeltaDiscretizedOptimizedOverThreshold = Après discrétisation, le moyen de compensation ${shuntCompensatorId} avec ${maxSectionCount} gradin(s) disponible(s) a été réglé à ${discretizedValue} MVar (valeur optimisée : ${optimalValue} MVar).
-optimizer.openreac.shuntCompensatorDeltaOverThreshold = La différence entre la valeur discrétisée et la valeur théorique optimisée de la puissance réactive dépasse le seuil fixé.
-optimizer.openreac.shuntCompensatorDeltaOverThresholdCount = Pour ${shuntsCount} moyen(s) de compensation, la différence entre la valeur discrétisée et la valeur théorique optimisée de la puissance réactive dépasse le seuil fixé.
-optimizer.openreac.variableShuntCompensatorsSize = ${size} moyen(s) de compensation ont des gradins considérés comme variables.
-optimizer.openreac.variableTwoWindingsTransformersSize = ${size} transformateurs deux enroulements ont des régleurs considérés comme variables.
+optimizer.openreac.constantQGeneratorsSize = La consigne de puissance rÃ©active est considÃ©rÃ©e fixe pour ${size} gÃ©nÃ©rateurs.
+optimizer.openreac.nbVoltageLevelsWithInconsistentLimits = La limite haute et/ou basse en tension est/sont incohÃ©rente(s) pour ${size} poste(s).
+optimizer.openreac.nbVoltageLevelsWithLimitsOutOfNominalVRange = L'intervalle de tension acceptable semble incohÃ©rent avec la tension nominale pour ${size} poste(s).
+optimizer.openreac.nbVoltageLevelsWithMissingLimits = ${size} poste(s) ont une limite basse et/ou haute en tension indÃ©finie(s).
+optimizer.openreac.openReac = Open Reac sur le rÃ©seau '${networkId}' avec la fonction objectif ${objective}.
+optimizer.openreac.openReacParameterIntegrity = VÃ©rification de l'intÃ©gritÃ© des paramÃ¨tres Open reac sur le rÃ©seau '${networkId}'.
+optimizer.openreac.shuntCompensatorDeltaDiscretizedOptimizedOverThreshold = AprÃ¨s discrÃ©tisation, le moyen de compensation ${shuntCompensatorId} avec ${maxSectionCount} gradin(s) disponible(s) a Ã©tÃ© rÃ©glÃ© Ã  ${discretizedValue} MVar (valeur optimisÃ©e : ${optimalValue} MVar).
+optimizer.openreac.shuntCompensatorDeltaOverThreshold = La diffÃ©rence entre la valeur discrÃ©tisÃ©e et la valeur thÃ©orique optimisÃ©e de la puissance rÃ©active dÃ©passe le seuil fixÃ©.
+optimizer.openreac.shuntCompensatorDeltaOverThresholdCount = Pour ${shuntsCount} moyen(s) de compensation, la diffÃ©rence entre la valeur discrÃ©tisÃ©e et la valeur thÃ©orique optimisÃ©e de la puissance rÃ©active dÃ©passe le seuil fixÃ©.
+optimizer.openreac.variableShuntCompensatorsSize = ${size} moyen(s) de compensation ont des gradins considÃ©rÃ©s comme variables.
+optimizer.openreac.variableTwoWindingsTransformersSize = ${size} transformateurs deux enroulements ont des rÃ©gleurs considÃ©rÃ©s comme variables.
 optimizer.openreac.voltageLevelsLimitsOutOfNominalVRange = Les limites en tension du poste sont en dehors de l'intervalle nominal de tension.
 optimizer.openreac.voltageLevelWithBothLimitsMissing = Les limites haute et basse du poste ${vlId} sont manquantes.
-optimizer.openreac.voltageLevelWithInconsistentLimits = ${vlId} a une ou deux limites en tension incohérentes (limite en tension basse = ${low}, limite en tension haute = ${high}).
-optimizer.openreac.voltageLevelWithLimitsOutOfNominalVRange = L'intervalle de tension acceptable pour le poste ${vID} semble incohérent avec la tension nominale : limite basse de tension = ${lowVoltageLimit} kV, limite haute de tension = ${highVoltageLimit} kV, tension nominale = ${nominalVoltage} kV.
+optimizer.openreac.voltageLevelWithInconsistentLimits = ${vlId} a une ou deux limites en tension incohÃ©rentes (limite en tension basse = ${low}, limite en tension haute = ${high}).
+optimizer.openreac.voltageLevelWithLimitsOutOfNominalVRange = L'intervalle de tension acceptable pour le poste ${vID} semble incohÃ©rent avec la tension nominale : limite basse de tension = ${lowVoltageLimit} kV, limite haute de tension = ${highVoltageLimit} kV, tension nominale = ${nominalVoltage} kV.
 optimizer.openreac.voltageLevelWithLowerLimitMissing = La limite basse de tension du poste ${vlId} est manquante.
 optimizer.openreac.voltageLevelWithUpperLimitMissing = La limite haute de tension du poste ${vlId} est manquante.


### PR DESCRIPTION
Since java9 jep 226, resource bundle are read in utf8 and if that fails reread as latin1 so it's actually very slightly better for performance and more aligned with the platform to distribute them in utf8 now and everything works the same

Switching to utf8 also prevents that people by accident rewrite the whole file and replace all latin1 characters by the unicode error character � (some editors do this, I saw it with vscode)

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
properties in latin1


**What is the new behavior (if this is a feature change)?**
properties in utf8


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
